### PR TITLE
Update test_tle.py to mock the response from an external API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,10 +37,7 @@ jobs:
         run: docker build . --file Dockerfile --target test --build-arg BASE_IMAGE_PYTHON_VERSION=${{ matrix.python-version }} --tag curryer-${{ matrix.python-version }}-test:latest
 
       - name: Run test docker image
-        env:
-          SPACETRACK_USER: ${{ secrets.SPACETRACK_USER }}
-          SPACETRACK_PSWD: ${{ secrets.SPACETRACK_PSWD }}
-        run: docker run -i --rm -e SPACETRACK_USER="$SPACETRACK_USER" -e SPACETRACK_PSWD="$SPACETRACK_PSWD" curryer-${{ matrix.python-version }}-test:latest
+        run: docker run -i --rm curryer-${{ matrix.python-version }}-test:latest
 
   demo:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ pytest-cov = "*"
 pytest-randomly = "*"
 ruff = "*"
 ipython = "*"
+responses = "^0.25.8"
 
 #[tool.poetry.scripts]
 #curryer = 'curryer.__main__:main'

--- a/tests/test_tle.py
+++ b/tests/test_tle.py
@@ -1,9 +1,10 @@
 import logging
-import os
+import re
 import unittest
 
 import numpy as np
 import pandas as pd
+import responses
 
 from curryer import tle, utils
 
@@ -14,11 +15,97 @@ utils.enable_logging(extra_loggers=[__name__])
 class TLETestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.ctim_norad_id = 52950
-        self.__spacetrack_user = os.getenv("SPACETRACK_USER")
-        self.__spacetrack_pswd = os.getenv("SPACETRACK_PSWD")
 
+        # Mock the authentication POST request
+        responses.post(
+            "https://www.space-track.org/ajaxauth/login", status=200, adding_headers={"Set-Cookie": "test-cookie"}
+        )
+
+        # Example response retrieved 10/23/2025 from Space-Track.org for CTIM TLEss
+        responses.add(
+            responses.GET,
+            re.compile(r"https://www\.space-track\.org/basicspacedata/query/class/gp_history/.*"),
+            json={
+                "request_metadata": {
+                    "Total": 7,
+                    "Limit": 1000000,
+                    "LimitOffset": 1,
+                    "ReturnedRows": 7,
+                    "RequestTime": "0.0156",
+                    "DataSize": "1.4 KB",
+                },
+                "data": [
+                    {
+                        "OBJECT_NAME": "CTIM",
+                        "NORAD_CAT_ID": "52950",
+                        "EPOCH": "2023-08-05T21:28:55.890912",
+                        "CREATION_DATE": "2023-08-06T07:36:12",
+                        "FILE": "3972943",
+                        "TLE_LINE1": "1 52950U 22074G   23217.89509133  .00091375  00000-0  16656-2 0  9990",
+                        "TLE_LINE2": "2 52950  44.9972  80.4362 0013702 194.0738 165.9772 15.48414179 61295",
+                    },
+                    {
+                        "OBJECT_NAME": "CTIM",
+                        "NORAD_CAT_ID": "52950",
+                        "EPOCH": "2023-08-05T01:21:11.371104",
+                        "CREATION_DATE": "2023-08-05T14:56:14",
+                        "FILE": "3972329",
+                        "TLE_LINE1": "1 52950U 22074G   23217.05638161  .00085666  00000-0  15720-2 0  9999",
+                        "TLE_LINE2": "2 52950  44.9967  85.1619 0013618 188.5025 171.5637 15.48253066 61164",
+                    },
+                    {
+                        "OBJECT_NAME": "CTIM",
+                        "NORAD_CAT_ID": "52950",
+                        "EPOCH": "2023-08-04T02:07:29.930304",
+                        "CREATION_DATE": "2023-08-04T22:56:12",
+                        "FILE": "3971760",
+                        "TLE_LINE1": "1 52950U 22074G   23216.08854086  .00068430  00000-0  12662-2 0  9999",
+                        "TLE_LINE2": "2 52950  44.9969  90.6136 0013476 181.9313 178.1528 15.48111360 61016",
+                    },
+                    {
+                        "OBJECT_NAME": "CTIM",
+                        "NORAD_CAT_ID": "52950",
+                        "EPOCH": "2023-08-03T02:53:41.057376",
+                        "CREATION_DATE": "2023-08-03T22:46:13",
+                        "FILE": "3970883",
+                        "TLE_LINE1": "1 52950U 22074G   23215.12061409  .00077375  00000-0  14365-2 0  9992",
+                        "TLE_LINE2": "2 52950  44.9972  96.0650 0013327 175.6137 184.4873 15.47967214 60861",
+                    },
+                    {
+                        "OBJECT_NAME": "CTIM",
+                        "NORAD_CAT_ID": "52950",
+                        "EPOCH": "2023-08-03T01:20:45.519360",
+                        "CREATION_DATE": "2023-08-03T07:06:12",
+                        "FILE": "3970323",
+                        "TLE_LINE1": "1 52950U 22074G   23215.05608240  .00087555  00000-0  16230-2 0  9998",
+                        "TLE_LINE2": "2 52950  44.9972  96.4283 0013299 175.3139 184.7879 15.47958490 60858",
+                    },
+                    {
+                        "OBJECT_NAME": "CTIM",
+                        "NORAD_CAT_ID": "52950",
+                        "EPOCH": "2023-08-02T09:51:27.952416",
+                        "CREATION_DATE": "2023-08-02T14:56:13",
+                        "FILE": "3969741",
+                        "TLE_LINE1": "1 52950U 22074G   23214.41074019  .00072198  00000-0  13476-2 0  9994",
+                        "TLE_LINE2": "2 52950  44.9974 100.0626 0013220 170.7779 189.3356 15.47843836 60753",
+                    },
+                    {
+                        "OBJECT_NAME": "CTIM",
+                        "NORAD_CAT_ID": "52950",
+                        "EPOCH": "2023-08-01T02:52:41.704032",
+                        "CREATION_DATE": "2023-08-01T06:56:13",
+                        "FILE": "3968646",
+                        "TLE_LINE1": "1 52950U 22074G   23213.11992713  .00078271  00000-0  14692-2 0  9999",
+                        "TLE_LINE2": "2 52950  44.9973 107.3271 0013094 161.8408 198.2952 15.47650271 60555",
+                    },
+                ],
+            },
+            status=200,
+        )
+
+    @responses.activate
     def test_ctim_tle_read(self):
-        accessor = tle.TLERemoteAccessor(self.__spacetrack_user, self.__spacetrack_pswd)
+        accessor = tle.TLERemoteAccessor("", "")
         table = accessor.read(
             self.ctim_norad_id, query_args=[("epoch", "range", ("2023-08-01", "2023-08-06"))], index_col="epoch"
         )


### PR DESCRIPTION
Removes the dependency on the external space-track.org API, which was causing issues when running unit tests. This API is used for CTIM and TSIS-2 but is not needed for other missions, and requires a username/password combination to access. 

Although this API is still used in some instances internally, this makes it so that most developers and users should not need that username/password combo. It also ensures the unit tests can run in a fork without the set up secret values for authentication. 

This PR also includes some weird conflicts with other open PRs but I am planning to merge this after, so you can skip most of the duplicate poetry.lock/.gitignore bits as they will get removed once those other PRs are merged. I can remove those pieces if they are confusing for this review.