### PR TITLE
34 add test coverage monitoring with codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,15 @@ jobs:
         run: docker build . --file Dockerfile --target test --build-arg BASE_IMAGE_PYTHON_VERSION=${{ matrix.python-version }} --tag curryer-${{ matrix.python-version }}-test:latest
 
       - name: Run test docker image
-        run: docker run -i --rm curryer-${{ matrix.python-version }}-test:latest
+        run: docker run -i curryer-${{ matrix.python-version }}-test:latest
+
+      - name: Copy coverage report
+        run: docker cp $(docker ps -alq):/app/curryer/coverage.xml ./coverage.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          oidc: true
 
   demo:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,12 @@
 # Configuration for pre-commit CI github app integration
-ci:
-  autofix_prs: false
-  autoupdate_schedule: "quarterly" # Checks for hook updates pulled from pre-commit hook repo
-  skip: [no-commit-to-branch] # Allows checks to run on main branch in CI
+# Reference: https://pre-commit.ci/
+# ci:
+#   autofix_prs: false
+#   autoupdate_schedule: "quarterly" # Checks for hook updates pulled from pre-commit hook repo
+#   skip: [no-commit-to-branch] # Allows checks to run on main branch in CI
+
 # Configuration for pre-commit hooks (local or in CI)
+# Reference: https://pre-commit.com/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -35,3 +38,7 @@ repos:
         additional_dependencies:
           - tomli
         files: ^.*\.(py|md|rst|yml)$
+  - repo: https://github.com/mashi/codecov-validator
+    rev: 1.0.1
+    hooks:
+      - id: ccv

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN PROJ_DOWNLOAD_DIR=$(python -c "import pyproj; print(pyproj.datadir.get_user_
     && mkdir -p ${PROJ_DOWNLOAD_DIR} \
     && curl https://cdn.proj.org/us_nga_egm96_15.tif --output ${PROJ_DOWNLOAD_DIR}/us_nga_egm96_15.tif
 
-ENTRYPOINT ["pytest", "-v", "--junitxml=junit.xml", "--disable-warnings", "tests"]
+ENTRYPOINT ["pytest", "-v", "--junitxml=junit.xml", "--cov", "--cov-branch", "--cov-report=xml:coverage.xml", "--disable-warnings", "tests"]
 
 # =============================================================================
 # Debug environment.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+# Codecov configuration for space_packet_parser
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  status:
+    project:
+      default:
+        target: 85% # Target coverage percentage
+        threshold: 5% # Allow 5% drop without failing
+        if_no_uploads: error # Fail if no coverage data
+        only_pulls: false # Check coverage on all commits
+
+      # Custom group for tests module with higher threshold
+      tests:
+        target: 95% # Very high threshold for test files
+        threshold: 1% # Allow only 1% drop
+        paths:
+          - "tests/**" # Adjust this path to match your test directory
+        if_no_uploads: error
+        only_pulls: false
+
+    patch:
+      default:
+        target: 85% # Lower threshold for new code
+        threshold: 5%
+        only_pulls: true # Only check patch coverage on PRs
+
+  ignore:
+    - "bin/**/*" # Don't include utility scripts
+    - "docs/**/*" # Don't include documentation


### PR DESCRIPTION
This PR builds on top of #46 and includes code coverage reporting to Codecov. The tests container entrypoint has been updated to include a coverage report xml file and the test Action workflow now copies that report out of the container and uploads it to codecov.

I also added a pre-commit hook that validates the format of the codecov config file.