### PR TITLE
Remove Docker from tests Workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__
 venv
 .venv
 poetry.lock
+.coverage
+coverage.xml
 
 # Sphinx
 # ------

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ COPY pyproject.toml $BASE_DIR
 RUN pip install --upgrade pip
 
 # Install all dependencies (including dev deps) specified in pyproject.toml
-RUN poetry install
+RUN poetry lock && poetry install
 
 # Download third-party data.
 ENV CURRYER_DATA_DIR=$DATA_DIR


### PR DESCRIPTION
Remove the need to build and run docker containers for the tests Github actions workflow. Replace with inline apt installs and pip install.