### PR TITLE
Raise test time limit to 12 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]


### PR DESCRIPTION
The Python 3.12 tests keep timing out, so this is a small bump to see if we can get them to run consistently.