### PR TITLE
Add readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,5 @@ sphinx:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - requirements: pyproject.toml
+    - method: pip
+      path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Since these are only for testing, we do not care what version they are
-test = ["pre-commit", "pytest", "pytest-cov", "pytest-randomly", "ruff"]
+test = ["pre-commit", "pytest", "pytest-cov", "pytest-randomly", "ruff", "responses"]
 
 [tool.poetry]
 packages = [{ include = "curryer" }]
@@ -73,6 +73,8 @@ pytest-randomly = "*"
 ruff = "*"
 ipython = "*"
 responses = "^0.25.8"
+sphinx = "*"
+myst-parser = "*" 
 
 #[tool.poetry.scripts]
 #curryer = 'curryer.__main__:main'


### PR DESCRIPTION
Completes #35. 

This sets up readthedocs, and adds some doc related dependencies that I think were accidentally removed.

The readthedocs URL is set up under lasp-curryer.