### PR TITLE
Drop support for Python 3.9, add 3.13 to matrix tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 12
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     defaults:
       run:
         shell: bash

--- a/curryer/compute/elevation.py
+++ b/curryer/compute/elevation.py
@@ -14,7 +14,6 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -50,7 +49,7 @@ class Elevation:
     LON_MID = -180 % LON_STEP
     LAT_MID = -90 % LAT_STEP
 
-    def __init__(self, data_dir: Union[str, Path] = None, meters=False, degrees=True):
+    def __init__(self, data_dir: str | Path = None, meters=False, degrees=True):
         """Initialize elevation data handling.
 
         Parameters
@@ -331,8 +330,8 @@ class Elevation:
         arcsec: float = None,
         stat: str = "mea",
         wrap_lon=False,
-        degrees: Union[bool, None] = None,
-    ) -> Optional[pd.Series]:
+        degrees: bool | None = None,
+    ) -> pd.Series | None:
         """Find the DEM file for a given lon/lat point.
 
         Parameters
@@ -455,8 +454,8 @@ class Elevation:
 
     @track_performance
     def get_geoid_height(
-        self, lon: Union[np.ndarray, float], lat: Union[np.ndarray, float], degrees: Union[bool, None] = None
-    ) -> Union[np.ndarray, float]:
+        self, lon: np.ndarray | float, lat: np.ndarray | float, degrees: bool | None = None
+    ) -> np.ndarray | float:
         """Query the geoid height for a given lon/lat(s).
 
         Parameters
@@ -490,7 +489,7 @@ class Elevation:
         return hts if self.meters else hts / 1e3
 
     @track_performance
-    def get_dem_height(self, lon: float, lat: float, filepath: Path, degrees: Union[bool, None] = None) -> float:
+    def get_dem_height(self, lon: float, lat: float, filepath: Path, degrees: bool | None = None) -> float:
         """Query the DEM height above the geoid for a given lon/lat.
 
         Parameters
@@ -853,8 +852,8 @@ class ElevationRegion:
         dx: float,
         dy: float,
         orthometric=None,
-        meters: Union[bool, None] = None,
-        degrees: Union[bool, None] = None,
+        meters: bool | None = None,
+        degrees: bool | None = None,
     ):
         """Initialize the region's elevation data.
 
@@ -930,9 +929,7 @@ class ElevationRegion:
         return cls(data, ulx, uly, dx, dy, **kwargs)
 
     @track_performance
-    def query(
-        self, lon: Union[np.ndarray, float], lat: Union[np.ndarray, float], orthometric=None
-    ) -> Union[np.ndarray, float]:
+    def query(self, lon: np.ndarray | float, lat: np.ndarray | float, orthometric=None) -> np.ndarray | float:
         """Query the surface (DEM + geoid) height above the ellipsoid a given
         lon/lat.
 

--- a/curryer/compute/spatial.py
+++ b/curryer/compute/spatial.py
@@ -20,7 +20,6 @@ Terms:
 
 import logging
 import time
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -37,7 +36,7 @@ EARTH_FRAME = "ITRF93"  # High-accuracy, requires extra kernels.
 # 'IAU_EARTH' is low-accuracy, but built-in.
 
 
-def pixel_vectors(instrument: Union[int, str, spicierpy.obj.Body]) -> tuple[int, np.ndarray]:
+def pixel_vectors(instrument: int | str | spicierpy.obj.Body) -> tuple[int, np.ndarray]:
     """Load the pixel or boresight vector(s) for a given instrument.
 
     Boresight vector is queried from the instrument kernel, but superseded by
@@ -85,7 +84,7 @@ def pixel_vectors(instrument: Union[int, str, spicierpy.obj.Body]) -> tuple[int,
 
 def instrument_pointing_state(
     ugps_times: np.ndarray,
-    instrument: Union[int, str, spicierpy.obj.Body],
+    instrument: int | str | spicierpy.obj.Body,
     correction: str = None,
     allow_nans=True,
     boresight_vector=None,
@@ -211,7 +210,7 @@ def instrument_pointing_state(
 
 def instrument_intersect_ellipsoid(
     ugps_times: np.ndarray,
-    instrument: Union[int, str, spicierpy.obj.Body],
+    instrument: int | str | spicierpy.obj.Body,
     correction: str = None,
     allow_nans=True,
     boresight_vector=None,
@@ -957,7 +956,7 @@ def calc_zenith(obs_position: np.ndarray, trg_position: np.ndarray, degrees=Fals
 def surface_angles(
     surface_positions: pd.DataFrame,
     target_positions: pd.DataFrame = None,
-    target_obj: Union[int, str, spicierpy.obj.Body] = None,
+    target_obj: int | str | spicierpy.obj.Body = None,
     degrees=False,
     allow_nans=False,
     signed=False,
@@ -1060,7 +1059,7 @@ def minmax_lon(lons: np.ndarray, degrees=False) -> (float, float):
 class Geolocate:
     """High-level class to manage the geolocation processing steps."""
 
-    def __init__(self, instrument: Union[str, int, spicierpy.obj.Body], dem_data_dir=None):
+    def __init__(self, instrument: str | int | spicierpy.obj.Body, dem_data_dir=None):
         """Set up the geolocation process.
 
         Parameters

--- a/curryer/correction/correction_config.py
+++ b/curryer/correction/correction_config.py
@@ -7,7 +7,7 @@ configuration files. It contains NO mission-specific logic.
 import json
 import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def get_kernel_mapping(config_data: dict[str, Any], kernel_type: str) -> dict[st
     return kernel_mappings.get(kernel_type, {})
 
 
-def find_kernel_file(name: str, kernel_mapping: dict[str, str]) -> Optional[str]:
+def find_kernel_file(name: str, kernel_mapping: dict[str, str]) -> str | None:
     """Find kernel file for a given name using substring matching.
 
     Performs case-insensitive matching against kernel mapping keys.

--- a/curryer/correction/geolocation_error_stats.py
+++ b/curryer/correction/geolocation_error_stats.py
@@ -15,7 +15,7 @@ The main processing pipeline:
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -33,11 +33,11 @@ class GeolocationConfig:
     earth_radius_m: float  # Earth radius in meters (e.g., WGS84: 6378140.0)
     performance_threshold_m: float  # Accuracy threshold (e.g., 250.0)
     performance_spec_percent: float  # Performance requirement percentage (e.g., 39.0)
-    minimum_correlation: Optional[float] = None  # Filter threshold (0.0-1.0)
+    minimum_correlation: float | None = None  # Filter threshold (0.0-1.0)
 
     # Mission-agnostic variable name mappings
     # Maps semantic names to actual variable names in the dataset
-    variable_names: Optional[dict[str, str]] = None  # If None, uses CLARREO defaults
+    variable_names: dict[str, str] | None = None  # If None, uses CLARREO defaults
 
     @classmethod
     def from_monte_carlo_config(cls, mc_config) -> "GeolocationConfig":
@@ -449,7 +449,7 @@ class ErrorStatsProcessor:
 
         return output_ds
 
-    def _calculate_statistics(self, nadir_equiv_errors_m: np.ndarray) -> dict[str, Union[float, int]]:
+    def _calculate_statistics(self, nadir_equiv_errors_m: np.ndarray) -> dict[str, float | int]:
         """Calculate performance statistics on nadir-equivalent errors."""
 
         # Count errors below threshold
@@ -471,9 +471,7 @@ class ErrorStatsProcessor:
 
         return stats
 
-    def process_from_netcdf(
-        self, filepath: Union[str, "Path"], minimum_correlation: Optional[float] = None
-    ) -> xr.Dataset:
+    def process_from_netcdf(self, filepath: Union[str, "Path"], minimum_correlation: float | None = None) -> xr.Dataset:
         """
         Load previous results from NetCDF and reprocess error statistics.
 

--- a/curryer/correction/image_match.py
+++ b/curryer/correction/image_match.py
@@ -347,7 +347,7 @@ def load_optical_psf_from_mat(mat_file: Path, key: str = "PSF_struct_675nm") -> 
                 # Check if attribute exists first to avoid NumPy array boolean ambiguity
                 field_angle = getattr(entry, "FA", None)
                 if field_angle is None or (
-                    isinstance(field_angle, (list, tuple, np.ndarray)) and len(field_angle) == 0
+                    isinstance(field_angle, list | tuple | np.ndarray) and len(field_angle) == 0
                 ):
                     # Fallback if FA is missing, None, or empty
                     field_angle = getattr(entry, "field_angle", None)

--- a/curryer/correction/monte_carlo.py
+++ b/curryer/correction/monte_carlo.py
@@ -58,7 +58,7 @@ import typing
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -136,8 +136,8 @@ class CalibrationData(NamedTuple):
         List of optical PSF entries, or None if not using calibration
     """
 
-    los_vectors: Optional[np.ndarray]
-    optical_psfs: Optional[list]
+    los_vectors: np.ndarray | None
+    optical_psfs: list | None
 
 
 class ImageMatchingContext(NamedTuple):

--- a/curryer/correction/monte_carlo.py
+++ b/curryer/correction/monte_carlo.py
@@ -516,8 +516,8 @@ def image_matching(
     calibration_dir: Path,
     params_info: list,
     config: "MonteCarloConfig",
-    los_vectors_cached: Optional[np.ndarray] = None,
-    optical_psfs_cached: Optional[list] = None,
+    los_vectors_cached: np.ndarray | None = None,
+    optical_psfs_cached: list | None = None,
 ) -> xr.Dataset:
     """
     Image matching using integrated_image_match() module.
@@ -866,7 +866,7 @@ class ParameterType(Enum):
 @dataclass
 class ParameterConfig:
     ptype: ParameterType
-    config_file: typing.Optional[Path]
+    config_file: Path | None
     data: typing.Any
 
 
@@ -877,7 +877,7 @@ class GeolocationConfig:
     dynamic_kernels: [Path]  # Kernels that are dynamic but *not* altered by param!
     instrument_name: str
     time_field: str
-    minimum_correlation: typing.Optional[float] = None  # Filter threshold for image matching quality (0.0-1.0)
+    minimum_correlation: float | None = None  # Filter threshold for image matching quality (0.0-1.0)
 
 
 @dataclass
@@ -908,11 +908,11 @@ class NetCDFConfig:
 
     # Parameter metadata - maps parameter config to NetCDF metadata
     # If None, will be auto-generated from config.parameters
-    parameter_metadata: typing.Optional[dict[str, NetCDFParameterMetadata]] = None
+    parameter_metadata: dict[str, NetCDFParameterMetadata] | None = None
 
     # Standard variable attributes - allows mission-specific overrides
     # If None, uses STANDARD_NETCDF_ATTRIBUTES module constant
-    standard_attributes: typing.Optional[dict[str, dict[str, str]]] = None
+    standard_attributes: dict[str, dict[str, str]] | None = None
 
     def get_threshold_metric_name(self) -> str:
         """Generate metric name dynamically from threshold."""
@@ -934,7 +934,7 @@ class NetCDFConfig:
             return STANDARD_NETCDF_ATTRIBUTES.copy()
 
     def get_parameter_netcdf_metadata(
-        self, param_config: ParameterConfig, angle_type: typing.Optional[str] = None
+        self, param_config: ParameterConfig, angle_type: str | None = None
     ) -> NetCDFParameterMetadata:
         """
         Get NetCDF metadata for a parameter.
@@ -964,7 +964,7 @@ class NetCDFConfig:
         return self._auto_generate_metadata(param_config, angle_type, lookup_key)
 
     def _auto_generate_metadata(
-        self, param_config: ParameterConfig, angle_type: typing.Optional[str], base_key: str
+        self, param_config: ParameterConfig, angle_type: str | None, base_key: str
     ) -> NetCDFParameterMetadata:
         """Auto-generate NetCDF metadata from parameter configuration."""
 
@@ -1078,7 +1078,7 @@ class MonteCarloConfig:
     """
 
     # CORE MONTE CARLO SETTINGS
-    seed: typing.Optional[int]
+    seed: int | None
     n_iterations: int
     parameters: list[ParameterConfig]
 
@@ -1089,21 +1089,21 @@ class MonteCarloConfig:
     earth_radius_m: float
 
     # DATA LOADERS
-    telemetry_loader: typing.Optional[TelemetryLoader] = None
-    science_loader: typing.Optional[ScienceLoader] = None
-    gcp_loader: typing.Optional[GCPLoader] = None
+    telemetry_loader: TelemetryLoader | None = None
+    science_loader: ScienceLoader | None = None
+    gcp_loader: GCPLoader | None = None
 
     # PROCESSING FUNCTIONS
-    gcp_pairing_func: typing.Optional[GCPPairingFunc] = None
-    image_matching_func: typing.Optional[ImageMatchingFunc] = None
+    gcp_pairing_func: GCPPairingFunc | None = None
+    image_matching_func: ImageMatchingFunc | None = None
 
     # OUTPUT CONFIGURATION
-    netcdf: typing.Optional[NetCDFConfig] = None
-    output_filename: typing.Optional[str] = None
+    netcdf: NetCDFConfig | None = None
+    output_filename: str | None = None
 
     # CALIBRATION CONFIGURATION
-    calibration_dir: typing.Optional[Path] = None
-    calibration_file_names: typing.Optional[dict[str, str]] = None
+    calibration_dir: Path | None = None
+    calibration_file_names: dict[str, str] | None = None
 
     # MISSION-SPECIFIC NAMING
     spacecraft_position_name: str = "sc_position"

--- a/curryer/correction/pairing.py
+++ b/curryer/correction/pairing.py
@@ -94,7 +94,7 @@ def validate_pairing_output(pairs: list[tuple[str, str]]) -> None:
                 f"got {type(pair)} with length {len(pair) if isinstance(pair, tuple) else 'N/A'}"
             )
         sci_key, gcp_path = pair
-        if not isinstance(sci_key, str) or not isinstance(gcp_path, (str, Path)):
+        if not isinstance(sci_key, str) or not isinstance(gcp_path, str | Path):
             raise ValueError(
                 f"GCP pairing output[{i}] = ({type(sci_key).__name__}, {type(gcp_path).__name__}), expected (str, str)"
             )

--- a/curryer/kernels/create.py
+++ b/curryer/kernels/create.py
@@ -8,7 +8,7 @@ import json
 import logging
 import shutil
 import sys
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from itertools import chain
 from pathlib import Path
 
@@ -234,7 +234,7 @@ def batch_kernels(
         raise ValueError("can not specify both `time_range` and `lag_days`")
 
     if lag_days is not None:
-        dt = datetime.now(UTC).date()
+        dt = datetime.now(timezone.utc).date()
         dt0 = dt - timedelta(days=lag_days)
         dt1 = dt0 + timedelta(days=1)
         time_range = [dt0.isoformat(), dt1.isoformat()]

--- a/curryer/kernels/create.py
+++ b/curryer/kernels/create.py
@@ -52,7 +52,7 @@ class KernelCreator:
             parent_dir = self._parent_dir
 
         # File-based inputs.
-        if isinstance(input_obj, (str, Path)):
+        if isinstance(input_obj, str | Path):
             filename = Path(input_obj)
             if parent_dir and not filename.is_file() and not filename.is_absolute():
                 filename = (Path(parent_dir) / filename).resolve()
@@ -246,7 +246,7 @@ def batch_kernels(
             raise ValueError(f"If specified, `time_range` must contain two times in increasing order: {time_range}")
 
         if buffer_hours:
-            if not isinstance(buffer_hours, (list, tuple)):
+            if not isinstance(buffer_hours, list | tuple):
                 buffer_hours = [buffer_hours, buffer_hours]
             time_range = [time_range[0] - int(buffer_hours[0] * 3.6e9), time_range[1] + int(buffer_hours[1] * 3.6e9)]
 
@@ -254,7 +254,7 @@ def batch_kernels(
     n_config = len(kernel_configs)
     if output_kernels is not None:
         # TODO: Support output directory!
-        if not isinstance(output_kernels, (list, tuple)):
+        if not isinstance(output_kernels, list | tuple):
             raise TypeError(f"`output_kernels` must be a list/tuple, not: {type(output_kernels)}")
         if not n_config == len(output_kernels):
             raise ValueError("`output_kernels` must be the same length as `kernel_configs` or None")

--- a/curryer/kernels/create.py
+++ b/curryer/kernels/create.py
@@ -3,12 +3,12 @@
 @author: Brandon Stone
 """
 
-import datetime
 import importlib
 import json
 import logging
 import shutil
 import sys
+from datetime import UTC, datetime, timedelta
 from itertools import chain
 from pathlib import Path
 
@@ -234,9 +234,9 @@ def batch_kernels(
         raise ValueError("can not specify both `time_range` and `lag_days`")
 
     if lag_days is not None:
-        dt = datetime.datetime.utcnow().date()
-        dt0 = dt - datetime.timedelta(days=lag_days)
-        dt1 = dt0 + datetime.timedelta(days=1)
+        dt = datetime.now(UTC).date()
+        dt0 = dt - timedelta(days=lag_days)
+        dt1 = dt0 + timedelta(days=1)
         time_range = [dt0.isoformat(), dt1.isoformat()]
         time_format = "utc"
 

--- a/curryer/kernels/ephemeris.py
+++ b/curryer/kernels/ephemeris.py
@@ -412,7 +412,7 @@ class EphemerisTLEWriter(AbstractEphemerisWriter):
         tle_txt += "\n".join(row["tle_line1"] + "\n" + row["tle_line2"] for _, row in input_data.iterrows())
         tle_txt += "\n"  # SPICE will error out without this.
 
-        if isinstance(fobj_or_str, (str, Path)):
+        if isinstance(fobj_or_str, str | Path):
             Path(fobj_or_str).write_text(tle_txt)
         else:
             fobj_or_str.write(tle_txt)

--- a/curryer/kernels/writer.py
+++ b/curryer/kernels/writer.py
@@ -48,13 +48,13 @@ def update_invalid_paths(
     for key, value in configs.items():
         if re.search(r"_FILE(?:_NAME|)$", key) is None:
             continue
-        if isinstance(value, (str, Path)):
+        if isinstance(value, str | Path):
             value = [value]
 
         new_vals = []
         modified_value = False
         for item in value:
-            if not isinstance(item, (str, Path)):
+            if not isinstance(item, str | Path):
                 new_vals.append(item)
                 continue
 

--- a/curryer/kernels/writer.py
+++ b/curryer/kernels/writer.py
@@ -6,7 +6,7 @@
 import logging
 import os
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from io import StringIO
 from pathlib import Path
 
@@ -172,7 +172,7 @@ def write_setup(setup_file, template, configs, mappings=None, overwrite=False, v
         name=mappings.get("name"),
         code=mappings.get("code"),
         version=configs.pop("version", 0),
-        created=datetime.utcnow().strftime("%Y-%m-%d"),
+        created=datetime.now(UTC).strftime("%Y-%m-%d"),
         configs=configs,
     )  # TODO(stone): Add key 'APPEND_TO_OUTPUT' with self.append value? Or does cmd line flag override it anyway?
 

--- a/curryer/kernels/writer.py
+++ b/curryer/kernels/writer.py
@@ -6,7 +6,7 @@
 import logging
 import os
 import re
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from io import StringIO
 from pathlib import Path
 
@@ -172,7 +172,7 @@ def write_setup(setup_file, template, configs, mappings=None, overwrite=False, v
         name=mappings.get("name"),
         code=mappings.get("code"),
         version=configs.pop("version", 0),
-        created=datetime.now(UTC).strftime("%Y-%m-%d"),
+        created=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
         configs=configs,
     )  # TODO(stone): Add key 'APPEND_TO_OUTPUT' with self.append value? Or does cmd line flag override it anyway?
 

--- a/curryer/spicetime/convert.py
+++ b/curryer/spicetime/convert.py
@@ -151,7 +151,7 @@ def adapt(dt_val, from_=None, to=None, **kwargs):
     out_val = utils.apply_conversions(utils.find_mapping_path(conversions, from_, to), dt_val, **kwargs)
 
     # Make output match input if it was a list or tuple.
-    if isinstance(out_val, np.ndarray) and isinstance(dt_val, (list, tuple)):
+    if isinstance(out_val, np.ndarray) and isinstance(dt_val, list | tuple):
         out_val = type(dt_val)(out_val.tolist())
 
     return out_val

--- a/curryer/spicetime/utils.py
+++ b/curryer/spicetime/utils.py
@@ -107,7 +107,7 @@ class InputAsArray:
                 times = np.array([times], dtype=self.dtype)
 
             # Handle non-array iterable.
-            elif not isinstance(times, (np.ndarray, pd.Series)):
+            elif not isinstance(times, np.ndarray | pd.Series):
                 times = np.array(times, dtype=self.dtype)
 
             # Handle arrays of the wrong type.

--- a/curryer/spicierpy/ext.py
+++ b/curryer/spicierpy/ext.py
@@ -64,9 +64,9 @@ class load_kernel:
 
     def _iter_load(self, kernels):
         """Load multiple kernels."""
-        if isinstance(kernels, (str, Path)):
+        if isinstance(kernels, str | Path):
             self.load(str(kernels))
-        elif isinstance(kernels, (list, tuple)):
+        elif isinstance(kernels, list | tuple):
             for k in kernels:
                 self._iter_load(k)
         elif hasattr(kernels, "keys"):

--- a/curryer/tle.py
+++ b/curryer/tle.py
@@ -311,7 +311,7 @@ class TLERemoteAccessor:
             TLE file text if `filename` was None, otherwise None is returned.
 
         """
-        if isinstance(filename, (str, Path)):
+        if isinstance(filename, str | Path):
             filename = Path(filename)
             if filename.is_file() and not overwrite and not append:
                 raise FileExistsError(filename)

--- a/curryer/utils.py
+++ b/curryer/utils.py
@@ -170,9 +170,7 @@ def capture_subprocess(cmd, timeout=3600, capture_output=False):
     return
 
 
-def enable_logging(
-    log_level=logging.DEBUG, log_file: typing.Union[bool, str, Path] = False, extra_loggers: list[str] = None
-):
+def enable_logging(log_level=logging.DEBUG, log_file: bool | str | Path = False, extra_loggers: list[str] = None):
     """Enable logging to the console and optionally to a file.
 
     Parameters

--- a/curryer/utils.py
+++ b/curryer/utils.py
@@ -8,7 +8,7 @@ import logging.config
 import subprocess
 import time
 import typing
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -225,7 +225,7 @@ def enable_logging(log_level=logging.DEBUG, log_file: bool | str | Path = False,
 
     # Optionally, add logging to a file.
     if log_file:
-        default_log_name = f"curryer.{datetime.now(UTC).strftime('%Y%m%dT%H%M%S')}.log"  # TODO[rename]
+        default_log_name = f"curryer.{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}.log"  # TODO[rename]
         if log_file is True:
             log_file = Path.cwd() / default_log_name
         else:

--- a/curryer/utils.py
+++ b/curryer/utils.py
@@ -3,12 +3,12 @@
 @author: Brandon Stone
 """
 
-import datetime
 import logging
 import logging.config
 import subprocess
 import time
 import typing
+from datetime import UTC, datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -225,7 +225,7 @@ def enable_logging(log_level=logging.DEBUG, log_file: bool | str | Path = False,
 
     # Optionally, add logging to a file.
     if log_file:
-        default_log_name = f"curryer.{datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%S')}.log"  # TODO[rename]
+        default_log_name = f"curryer.{datetime.now(UTC).strftime('%Y%m%dT%H%M%S')}.log"  # TODO[rename]
         if log_file is True:
             log_file = Path.cwd() / default_log_name
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "university of colorado",
     "naif"
 ]
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10,<4"
 license = { text = "MIT" }
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -24,9 +24,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
     "Operating System :: POSIX",

--- a/tests/test_correction/test_geolocation_error_stats.py
+++ b/tests/test_correction/test_geolocation_error_stats.py
@@ -34,7 +34,6 @@ import logging
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import numpy.testing as npt
@@ -60,7 +59,7 @@ np.set_printoptions(linewidth=120)
 # ============================================================================
 
 
-def _sample_from_validated_test_cases(n_measurements: int, seed: Optional[int] = None) -> xr.Dataset:
+def _sample_from_validated_test_cases(n_measurements: int, seed: int | None = None) -> xr.Dataset:
     """
     Sample test data from the validated 13 test cases with replacement.
 

--- a/tests/test_correction/test_monte_carlo.py
+++ b/tests/test_correction/test_monte_carlo.py
@@ -48,7 +48,6 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -170,7 +169,7 @@ def synthetic_image_matching(
     # Generate synthetic errors
     base_error = placeholder_cfg.base_error_m
     param_contribution = (
-        sum(abs(p) if isinstance(p, (int, float)) else np.linalg.norm(p) for _, p in params_info)
+        sum(abs(p) if isinstance(p, int | float) else np.linalg.norm(p) for _, p in params_info)
         * placeholder_cfg.param_error_scale
     )
     error_magnitude = base_error + param_contribution
@@ -273,7 +272,7 @@ def _generate_nadir_aligned_transforms(n_measurements, riss_ctrs, boresights_hs)
 # code separate from mission-agnostic core functionality.
 
 
-def discover_test_image_match_cases(test_data_dir: Path, test_cases: Optional[list[str]] = None) -> list[dict]:
+def discover_test_image_match_cases(test_data_dir: Path, test_cases: list[str] | None = None) -> list[dict]:
     """
     Discover available image matching test cases.
 
@@ -526,7 +525,7 @@ def run_image_matching_with_applied_errors(
     randomize_errors: bool = True,
     error_variation_percent: float = 3.0,
     cache_results: bool = True,
-    cached_result: Optional[xr.Dataset] = None,
+    cached_result: xr.Dataset | None = None,
 ) -> xr.Dataset:
     """
     Run image matching with artificial errors applied to test data.
@@ -757,7 +756,7 @@ def test_generate_clarreo_config_json():
 # =============================================================================
 
 
-def run_upstream_pipeline(n_iterations: int = 5, work_dir: Optional[Path] = None) -> tuple[list, dict, Path]:
+def run_upstream_pipeline(n_iterations: int = 5, work_dir: Path | None = None) -> tuple[list, dict, Path]:
     """
     Test UPSTREAM segment of Monte Carlo pipeline.
 
@@ -879,7 +878,7 @@ def run_upstream_pipeline(n_iterations: int = 5, work_dir: Optional[Path] = None
 
 
 def run_downstream_pipeline(
-    n_iterations: int = 5, test_cases: Optional[list[str]] = None, work_dir: Optional[Path] = None
+    n_iterations: int = 5, test_cases: list[str] | None = None, work_dir: Path | None = None
 ) -> tuple[list, dict, Path]:
     """
     Test DOWNSTREAM segment of Monte Carlo pipeline.


### PR DESCRIPTION
Completes #52. 

The tests started failing for 3.9, so this is to drop support now that 3.9 is EOL. The majority of the code should still work for 3.9 but it will no longer be officially supported or tested against. 