### PR TITLE
Bugfix: Add logging and testing to apply offsets in the Correction Loop

### DIFF
--- a/curryer/correction/correction.py
+++ b/curryer/correction/correction.py
@@ -1475,11 +1475,9 @@ def load_param_sets(config: CorrectionConfig) -> [ParameterConfig, typing.Any]:
             out_set.append((param, param_vals))
         output.append(out_set)
 
-    # Log summary of generated parameter sets
-    logger.info(f"Generated {len(output)} parameter sets with {len(output[0])} parameters each")
-
-    # Log a summary table of parameter values for verification
+    # Log summary of generated parameter sets & a table of parameter values for verification
     if output:
+        logger.info(f"Generated {len(output)} parameter sets with {len(output[0])} parameters each")
         logger.info("\nParameter Set Summary:")
         logger.info("-" * 100)
         for param_set_idx, param_set in enumerate(output):

--- a/curryer/correction/correction.py
+++ b/curryer/correction/correction.py
@@ -2075,10 +2075,16 @@ def _create_parameter_kernels(
             logger.info(f"      {a_param.ptype.name}: {param_name} (constant kernel data)")
         elif a_param.ptype == ParameterType.OFFSET_KERNEL:
             units = a_param.data.get("units", "")
-            logger.info(f"      {a_param.ptype.name}: {param_name} = {p_data:.6f} {units}")
+            logger.info(
+                f"      {a_param.ptype.name}: {param_name} = {p_data:.6f} "
+                f"(internal units; configured units: {units or 'unspecified'})"
+            )
         elif a_param.ptype == ParameterType.OFFSET_TIME:
             units = a_param.data.get("units", "")
-            logger.info(f"      {a_param.ptype.name}: {param_name} = {p_data:.6f} {units}")
+            logger.info(
+                f"      {a_param.ptype.name}: {param_name} = {p_data:.6f} "
+                f"(internal units; configured units: {units or 'unspecified'})"
+            )
 
         # Create static changing SPICE kernels
         if a_param.ptype == ParameterType.CONSTANT_KERNEL:

--- a/curryer/correction/correction.py
+++ b/curryer/correction/correction.py
@@ -1418,7 +1418,7 @@ def load_param_sets(config: CorrectionConfig) -> [ParameterConfig, typing.Any]:
 
                     # Convert to appropriate units if needed
                     if param.data.get("units") == "arcseconds":
-                        current_val_rad = np.deg2rad(current_value / 3600.0) if current_val != 0 else current_val
+                        current_val_rad = np.deg2rad(current_value / 3600.0) if current_value != 0 else current_value
                     else:
                         current_val_rad = current_value
                     param_vals = current_val_rad

--- a/tests/test_correction/test_correction.py
+++ b/tests/test_correction/test_correction.py
@@ -1827,13 +1827,15 @@ class CorrectionUnifiedTests(unittest.TestCase):
             ),
         )
 
-        # Apply time offset of 10 milliseconds
+        # Apply time offset - value must be in seconds
+        # This simulates the production flow where load_param_sets converts to seconds
         offset_ms = 10.0
+        offset_seconds = offset_ms / 1000.0  # Convert to internal units (seconds)
         original_mean = science_data["corrected_timestamp"].mean()
-        modified_data = correction.apply_offset(time_param_config, offset_ms, science_data)
+        modified_data = correction.apply_offset(time_param_config, offset_seconds, science_data)
 
-        # Verify offset was applied (milliseconds -> microseconds)
-        expected_offset_us = offset_ms * 1000.0
+        # Verify offset was applied correctly (seconds -> microseconds)
+        expected_offset_us = offset_ms * 1000.0  # 10 ms = 10000 µs
         actual_delta = modified_data["corrected_timestamp"].mean() - original_mean
         self.assertAlmostEqual(actual_delta, expected_offset_us, places=6)
         logger.info(f"✓ OFFSET_TIME: {offset_ms} ms = {expected_offset_us:.6f} µs")
@@ -1842,8 +1844,9 @@ class CorrectionUnifiedTests(unittest.TestCase):
         logger.info("\nTest 5: OFFSET_TIME with negative offset")
 
         offset_ms = -5.5
+        offset_seconds = offset_ms / 1000.0  # Convert to internal units (seconds)
         original_mean = science_data["corrected_timestamp"].mean()
-        modified_data = correction.apply_offset(time_param_config, offset_ms, science_data)
+        modified_data = correction.apply_offset(time_param_config, offset_seconds, science_data)
 
         # Verify
         expected_offset_us = offset_ms * 1000.0


### PR DESCRIPTION
The main objective of this PR is to fix an edge case bug where some parameters (e.g. hps.az_ang_nonlin, etc) were quietly not being updated correctly with applied offsets, including in the tests. 

The other focus is making the parameter application process more transparent and robust. This pull request introduces logging and testing for parameter offset application in the correction pipeline. The logging makes for easier debugging and verification, and the tests cover expected parameter types and edge cases.

**Logging and Transparency Enhancements:**

* Added detailed logging of generated parameter sets, including a summary table with parameter values and unit conversions for verification in `load_param_sets`.
* Improved logging in `apply_offset` to show before/after statistics (mean values and deltas) for modified fields, unit conversions performed, and warnings for missing fields or columns.
* Added logging of parameter details (type, field, value, units) during kernel creation in `_create_parameter_kernels` for better traceability.

**Testing:**

* Added a comprehensive test function `test_apply_offset_function` covering all parameter types (`OFFSET_KERNEL`, `OFFSET_TIME`, `CONSTANT_KERNEL`), unit conversions, negative offsets, missing fields, pass-through behavior, and ensuring data is not modified in place. Also verifies preservation of DataFrame columns.

These changes greatly improve the maintainability and reliability of the correction module by making parameter application steps clear and testable.