### PR TITLE
Minor bug fix within terrain correction

### DIFF
--- a/curryer/compute/spatial.py
+++ b/curryer/compute/spatial.py
@@ -908,7 +908,8 @@ def terrain_correct(
     gd_cur_xyz[:, 2] = np.zeros(npts)
 
     # 10) Terrain intersection.
-    gd_cur_h = elev.query(gd_cur_xyz[:, 0], gd_cur_xyz[:, 1])
+    gd_cur_h = np.full(npts, np.nan)
+    gd_cur_h[idx_ang_valid] = elev.query(gd_cur_xyz[idx_ang_valid, 0], gd_cur_xyz[idx_ang_valid, 1])
     gd_prev_h = gd_cur_h.copy()
 
     # Initialize to the max local height.


### PR DESCRIPTION
Minor bug fix within terrain correction that caused a DEM query error under an extreme pointing scenario (intersect ellipsoid with near 90deg off nadir pointing). Required for Clarreo end-to-end testing.

This same logic (excluding high off nadir points from DEM query) occurs later within the terrain correction. The bug was that it wasn't being excluded from the initial query. We never encountered an issue before because usually (every time before) the first query is within the bounding box of the queried DEM data.