### PR TITLE
125 pr 21 introduce pydantic correctionconfig with typed sub models

### DIFF
--- a/curryer/correction/config.py
+++ b/curryer/correction/config.py
@@ -139,7 +139,8 @@ class ParameterData(BaseModel):
     units
         Physical units string, e.g. ``"arcseconds"`` or ``"milliseconds"``.
     distribution
-        Sampling distribution name (currently only ``"normal"`` is used).
+        Sampling distribution name.  Stored for documentation purposes;
+        the current implementation always uses a normal distribution.
     field
         Telemetry / science DataFrame column that this parameter modifies
         (required for ``OFFSET_KERNEL`` and ``OFFSET_TIME``).
@@ -160,18 +161,6 @@ class ParameterData(BaseModel):
     field: str | None = None
     transformation_type: str | None = None
     coordinate_frames: list[str] | None = None
-
-    @model_validator(mode="before")
-    @classmethod
-    def _handle_legacy_aliases(cls, data: Any) -> Any:
-        """Remap legacy dict keys (``center`` → ``current_value``, ``arange`` → ``bounds``)."""
-        if isinstance(data, dict):
-            data = dict(data)  # defensive copy
-            if "center" in data and "current_value" not in data:
-                data["current_value"] = data.pop("center")
-            if "arange" in data and "bounds" not in data:
-                data["bounds"] = data.pop("arange")
-        return data
 
     # ------------------------------------------------------------------
     # Backward-compatible dict-style access

--- a/curryer/correction/config.py
+++ b/curryer/correction/config.py
@@ -1,9 +1,10 @@
-"""Configuration dataclasses and enumerations for the geolocation correction pipeline.
+"""Configuration models and enumerations for the geolocation correction pipeline.
 
 This module defines the data structures that represent the complete configuration
 for a correction analysis run, including:
 
 - ``ParameterType`` – enum of the three parameter variation strategies
+- ``ParameterData`` – typed container for a parameter's sampling spec
 - ``ParameterConfig`` – a single parameter to vary (kernel or time offset)
 - ``GeolocationConfig`` – SPICE kernel paths and instrument settings
 - ``NetCDFParameterMetadata`` / ``NetCDFConfig`` – NetCDF output metadata
@@ -15,32 +16,29 @@ for a correction analysis run, including:
 All mission-specific values (kernel filenames, parameter ranges, instrument names)
 live in mission configuration modules (e.g. ``tests/test_correction/clarreo_config.py``)
 and are injected via ``CorrectionConfig``.
+
+All config objects are ``pydantic.BaseModel`` subclasses which provide:
+- Automatic type validation and clear ``ValidationError`` messages on construction
+- Free JSON serialization via ``model_dump_json()`` / ``model_validate_json()``
+- IDE autocomplete on every field
 """
 
 import json
 import logging
-import typing
-from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 if TYPE_CHECKING:
     from curryer import meta
-
-from curryer.correction.dataio import GCPLoader, ScienceLoader, TelemetryLoader
-from curryer.correction.image_match import ImageMatchingFunc
-from curryer.correction.pairing import GCPPairingFunc
 
 # ============================================================================
 # Standard NetCDF Variable Attributes (Mission-Agnostic)
 # ============================================================================
 
-# Standard metric attributes for NetCDF output.
-# These are generic geolocation/error metrics that apply to most missions.
-# Missions can override these in their NetCDFConfig if needed.
 STANDARD_NETCDF_ATTRIBUTES = {
     # Geolocation error metrics (per GCP pair)
     "rms_error_m": {"units": "meters", "long_name": "RMS geolocation error"},
@@ -82,22 +80,12 @@ STANDARD_VAR_NAMES = {
 
 
 # ============================================================================
-# Pipeline Helper NamedTuples
+# Pipeline Helper NamedTuples (not config – pass-through state only)
 # ============================================================================
 
 
 class KernelContext(NamedTuple):
-    """Context for SPICE kernel loading during geolocation.
-
-    Attributes
-    ----------
-    mkrn : meta.MetaKernel
-        MetaKernel instance with SDS and mission kernels
-    dynamic_kernels : list[Path]
-        List of dynamic kernel file paths (SC-SPK, SC-CK)
-    param_kernels : list[Path]
-        List of parameter-specific kernel file paths
-    """
+    """Context for SPICE kernel loading during geolocation."""
 
     mkrn: "meta.MetaKernel"
     dynamic_kernels: list[Path]
@@ -105,34 +93,14 @@ class KernelContext(NamedTuple):
 
 
 class CalibrationData(NamedTuple):
-    """Pre-loaded calibration data for image matching.
-
-    Attributes
-    ----------
-    los_vectors : Optional[np.ndarray]
-        Line-of-sight vectors array, or None if not using calibration
-    optical_psfs : Optional[list]
-        List of optical PSF entries, or None if not using calibration
-    """
+    """Pre-loaded calibration data for image matching."""
 
     los_vectors: np.ndarray | None
     optical_psfs: list | None
 
 
 class ImageMatchingContext(NamedTuple):
-    """Context data needed for image matching operations.
-
-    Attributes
-    ----------
-    gcp_pairs : list[tuple]
-        List of GCP pairing tuples from pairing function
-    params : list[tuple]
-        List of (ParameterConfig, parameter_value) tuples for this iteration
-    pair_idx : int
-        Index of current GCP pair being processed
-    sci_key : str
-        Science dataset identifier for this pair
-    """
+    """Context data needed for image matching operations."""
 
     gcp_pairs: list[tuple]
     params: list[tuple]
@@ -151,11 +119,124 @@ class ParameterType(Enum):
     OFFSET_TIME = auto()  # Modify input timetags by an offset
 
 
-@dataclass
-class ParameterConfig:
+class ParameterData(BaseModel):
+    """Typed sampling specification for a single correction parameter.
+
+    Supports dict-style access (``get``, ``__getitem__``, ``__contains__``)
+    for backward compatibility with code written against the old ``dict``-based
+    ``ParameterConfig.data`` API.
+
+    Attributes
+    ----------
+    current_value
+        Baseline parameter value(s).  A scalar for OFFSET_KERNEL/OFFSET_TIME
+        and a 3-element list ``[roll, pitch, yaw]`` for CONSTANT_KERNEL.
+    bounds
+        ``[min, max]`` offset limits (same units as ``sigma``).
+    sigma
+        Standard deviation for normal-distribution sampling.  ``None`` means
+        the parameter is held fixed at ``current_value``.
+    units
+        Physical units string, e.g. ``"arcseconds"`` or ``"milliseconds"``.
+    distribution
+        Sampling distribution name (currently only ``"normal"`` is used).
+    field
+        Telemetry / science DataFrame column that this parameter modifies
+        (required for ``OFFSET_KERNEL`` and ``OFFSET_TIME``).
+    transformation_type
+        Optional hint consumed by kernel-creation routines (e.g.
+        ``"dcm_rotation"`` or ``"angle_bias"``).
+    coordinate_frames
+        Optional list of SPICE frame names affected by this parameter.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    current_value: float | list[float] = 0.0
+    bounds: list[float] = Field(default_factory=lambda: [-1.0, 1.0])
+    sigma: float | None = None
+    units: str | None = None
+    distribution: str = "normal"
+    field: str | None = None
+    transformation_type: str | None = None
+    coordinate_frames: list[str] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _handle_legacy_aliases(cls, data: Any) -> Any:
+        """Remap legacy dict keys (``center`` → ``current_value``, ``arange`` → ``bounds``)."""
+        if isinstance(data, dict):
+            data = dict(data)  # defensive copy
+            if "center" in data and "current_value" not in data:
+                data["current_value"] = data.pop("center")
+            if "arange" in data and "bounds" not in data:
+                data["bounds"] = data.pop("arange")
+        return data
+
+    # ------------------------------------------------------------------
+    # Backward-compatible dict-style access
+    # ------------------------------------------------------------------
+
+    def _get_raw(self, key: str) -> Any:
+        """Return the raw value for *key* from declared fields or extra fields."""
+        if key in type(self).model_fields:
+            return getattr(self, key, None)
+        extra = self.__pydantic_extra__ or {}
+        return extra.get(key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """``dict.get()`` shim for backward compatibility.
+
+        Returns *default* when the value is ``None`` (i.e. field was not
+        explicitly set), mirroring ``dict.get`` on a mapping that only
+        contains keys with non-``None`` values.
+        """
+        val = self._get_raw(key)
+        return default if val is None else val
+
+    def __contains__(self, key: str) -> bool:
+        """``key in data`` shim – ``True`` when the value is not ``None``."""
+        return self._get_raw(key) is not None
+
+    def __getitem__(self, key: str) -> Any:
+        """``data[key]`` shim for backward compatibility."""
+        if key in type(self).model_fields:
+            return getattr(self, key)
+        extra = self.__pydantic_extra__ or {}
+        if key in extra:
+            return extra[key]
+        raise KeyError(key)
+
+
+class ParameterConfig(BaseModel):
+    """A single parameter to vary during correction analysis.
+
+    Attributes
+    ----------
+    ptype
+        How this parameter is applied (constant kernel, offset kernel, or
+        time offset).
+    config_file
+        Path to the SPICE kernel JSON template, or ``None`` for time
+        offsets that require no kernel file.
+    data
+        Sampling specification.  Accepts a plain ``dict`` or ``None`` on
+        construction (Pydantic coerces both to :class:`ParameterData`
+        automatically; ``None`` becomes an empty ``ParameterData()``).
+    """
+
     ptype: ParameterType
-    config_file: Path | None
-    data: typing.Any
+    config_file: Path | None = None
+    data: ParameterData = Field(default_factory=ParameterData)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_none_data(cls, values: Any) -> Any:
+        """Convert ``data=None`` to an empty ``ParameterData`` (backward compat)."""
+        if isinstance(values, dict) and values.get("data") is None:
+            values = dict(values)
+            values["data"] = {}
+        return values
 
 
 # ============================================================================
@@ -163,14 +244,32 @@ class ParameterConfig:
 # ============================================================================
 
 
-@dataclass
-class GeolocationConfig:
+class GeolocationConfig(BaseModel):
+    """SPICE kernel paths and instrument settings for geolocation.
+
+    Attributes
+    ----------
+    meta_kernel_file
+        Path to the mission meta-kernel JSON file.
+    generic_kernel_dir
+        Directory containing generic/shared SPICE kernels.
+    dynamic_kernels
+        Kernels regenerated from telemetry each run (SC-SPK, SC-CK, etc.)
+        but *not* altered by parameter variations.
+    instrument_name
+        SPICE instrument name (e.g. ``"CPRS_HYSICS"``).
+    time_field
+        Column name in the science DataFrame that holds uGPS timestamps.
+    minimum_correlation
+        Optional image-matching quality filter threshold (0.0–1.0).
+    """
+
     meta_kernel_file: Path
     generic_kernel_dir: Path
-    dynamic_kernels: list[Path]  # Kernels that are dynamic but *not* altered by param!
+    dynamic_kernels: list[Path] = Field(default_factory=list)
     instrument_name: str
     time_field: str
-    minimum_correlation: float | None = None  # Filter threshold for image matching quality (0.0-1.0)
+    minimum_correlation: float | None = None
 
 
 # ============================================================================
@@ -178,38 +277,38 @@ class GeolocationConfig:
 # ============================================================================
 
 
-@dataclass
-class NetCDFParameterMetadata:
-    """Metadata for a single parameter in NetCDF output."""
+class NetCDFParameterMetadata(BaseModel):
+    """NetCDF metadata for a single output parameter variable."""
 
-    variable_name: str  # NetCDF variable name (e.g., 'param_hysics_roll')
-    units: str  # Units (e.g., 'arcseconds', 'milliseconds')
-    long_name: str  # Human-readable description
+    variable_name: str
+    units: str
+    long_name: str
 
 
-@dataclass
-class NetCDFConfig:
+class NetCDFConfig(BaseModel):
     """Configuration for NetCDF output structure and metadata.
 
-    This class defines the structure and metadata for NetCDF output files.
-    All mission-specific information should be provided here rather than
-    hardcoded in the correction module.
-
-    The performance_threshold_m is required and should match the value in
-    CorrectionConfig. It's used to generate threshold-specific variable names
-    in the NetCDF output (e.g., "percent_under_250m").
+    Attributes
+    ----------
+    performance_threshold_m
+        Accuracy threshold in metres used to derive threshold-specific
+        variable names (e.g. ``"percent_under_250m"``).
+    title
+        Global title attribute for the output NetCDF file.
+    description
+        Global description attribute for the output NetCDF file.
+    parameter_metadata
+        Optional mapping of parameter key → :class:`NetCDFParameterMetadata`.
+        Auto-generated from ``CorrectionConfig.parameters`` when ``None``.
+    standard_attributes
+        Optional mission-specific attribute overrides.  Falls back to the
+        module-level :data:`STANDARD_NETCDF_ATTRIBUTES` when ``None``.
     """
 
-    performance_threshold_m: float  # Required: accuracy threshold in meters
+    performance_threshold_m: float
     title: str = "Correction Geolocation Analysis Results"
     description: str = "Parameter sensitivity analysis"
-
-    # Parameter metadata - maps parameter config to NetCDF metadata
-    # If None, will be auto-generated from config.parameters
     parameter_metadata: dict[str, NetCDFParameterMetadata] | None = None
-
-    # Standard variable attributes - allows mission-specific overrides
-    # If None, uses STANDARD_NETCDF_ATTRIBUTES module constant
     standard_attributes: dict[str, dict[str, str]] | None = None
 
     def get_threshold_metric_name(self) -> str:
@@ -218,81 +317,51 @@ class NetCDFConfig:
         return f"percent_under_{threshold_m}m"
 
     def get_standard_attributes(self) -> dict[str, dict[str, str]]:
-        """
-        Get standard variable attributes, using mission overrides if provided.
-
-        Returns:
-            Dictionary mapping variable names to their attributes (units, long_name)
-        """
+        """Get standard variable attributes, using mission overrides if provided."""
         if self.standard_attributes is not None:
-            # Use mission-specific overrides
             return self.standard_attributes
-        else:
-            # Use module-level defaults
-            return STANDARD_NETCDF_ATTRIBUTES.copy()
+        return STANDARD_NETCDF_ATTRIBUTES.copy()
 
     def get_parameter_netcdf_metadata(
         self, param_config: "ParameterConfig", angle_type: str | None = None
-    ) -> NetCDFParameterMetadata:
-        """
-        Get NetCDF metadata for a parameter.
-
-        Args:
-            param_config: Parameter configuration
-            angle_type: For CONSTANT_KERNEL parameters: 'roll', 'pitch', or 'yaw'
-
-        Returns:
-            NetCDFParameterMetadata with variable name, units, and description
-        """
-        # Generate key for lookup
+    ) -> "NetCDFParameterMetadata":
+        """Get NetCDF metadata for a parameter."""
         if param_config.config_file:
             param_stem = param_config.config_file.stem
-            if angle_type:
-                lookup_key = f"{param_stem}_{angle_type}"
-            else:
-                lookup_key = param_stem
+            lookup_key = f"{param_stem}_{angle_type}" if angle_type else param_stem
         else:
             lookup_key = f"param_{param_config.ptype.name.lower()}"
 
-        # Try to find in provided metadata
         if self.parameter_metadata and lookup_key in self.parameter_metadata:
             return self.parameter_metadata[lookup_key]
 
-        # Auto-generate if not provided
         return self._auto_generate_metadata(param_config, angle_type, lookup_key)
 
     def _auto_generate_metadata(
         self, param_config: "ParameterConfig", angle_type: str | None, base_key: str
-    ) -> NetCDFParameterMetadata:
+    ) -> "NetCDFParameterMetadata":
         """Auto-generate NetCDF metadata from parameter configuration."""
-
-        # Determine units based on parameter type
         if param_config.ptype == ParameterType.CONSTANT_KERNEL:
             units = "arcseconds"
         elif param_config.ptype == ParameterType.OFFSET_KERNEL:
-            units = "arcseconds"  # Typical for angle offsets
+            units = "arcseconds"
         elif param_config.ptype == ParameterType.OFFSET_TIME:
             units = "milliseconds"
         else:
             units = "unknown"
 
-        # Check if units specified in parameter data
-        if isinstance(param_config.data, dict) and "units" in param_config.data:
-            units = param_config.data["units"]
+        # Use declared units field (replaces old isinstance(data, dict) check)
+        if param_config.data.units is not None:
+            units = param_config.data.units
 
-        # Generate variable name (ensure it starts with 'param_')
         var_name = base_key.replace(".", "_").replace("-", "_")
         if not var_name.startswith("param_"):
             var_name = f"param_{var_name}"
 
-        # Generate human-readable description
         if param_config.config_file:
-            # Extract frame names from config file path
             file_stem = param_config.config_file.stem
-            # Remove version numbers and file extensions
             clean_name = file_stem.replace("_v01", "").replace("_v02", "").replace(".attitude.ck", "")
             clean_name = clean_name.replace("_", " ").title()
-
             if angle_type:
                 long_name = f"{clean_name} {angle_type} correction"
             else:
@@ -308,8 +377,7 @@ class NetCDFConfig:
 # ============================================================================
 
 
-@dataclass
-class CorrectionConfig:
+class CorrectionConfig(BaseModel):
     """The configuration object for geolocation correction analysis.
 
     This config contains everything needed for a Correction run:
@@ -323,67 +391,51 @@ class CorrectionConfig:
 
     Create one CorrectionConfig object and pass it to pipeline.loop() to run.
 
+    Serialisation
+    -------------
+    ``model_dump_json()`` / ``model_validate_json()`` provide lossless
+    JSON round-trips for all typed fields.  Callable fields (loaders,
+    pairing/matching functions) are **excluded** from serialisation because
+    they cannot be represented as JSON; re-attach them after deserialising.
+
     Parameters
     ----------
-    CORE CORRECTION SETTINGS (Required - define what the analysis does):
-        seed : Optional[int]
+    CORE CORRECTION SETTINGS:
+        seed : int | None
             Random seed for reproducibility, or None for non-reproducible runs.
         n_iterations : int
-            Number of parameter set iterations (e.g., 5, 100, 1000).
+            Number of parameter set iterations.
         parameters : list[ParameterConfig]
-            List of parameters to vary (defines sensitivity analysis).
+            Parameters to vary (defines sensitivity analysis).
 
-    GEOLOCATION & PERFORMANCE REQUIREMENTS (Required - mission-specific settings):
+    GEOLOCATION & PERFORMANCE REQUIREMENTS:
         geo : GeolocationConfig
-            SPICE kernels and instrument configuration.
         performance_threshold_m : float
-            Nadir-equivalent accuracy threshold in meters (e.g., 250.0 for CLARREO).
         performance_spec_percent : float
-            Required percentage of observations meeting threshold (e.g., 39.0 for CLARREO).
         earth_radius_m : float
-            Earth radius for geodetic calculations (e.g., 6378137.0 for WGS84).
-        geo : GeolocationConfig
-            SPICE kernels and instrument configuration.
 
-    DATA LOADERS (Required for pipeline execution - mission-specific implementations):
-        telemetry_loader : Optional[TelemetryLoader], default=None
-            Load spacecraft telemetry. Must be set before calling pipeline.loop().
-        science_loader : Optional[ScienceLoader], default=None
-            Load science frame timing. Must be set before calling pipeline.loop().
-        gcp_loader : Optional[GCPLoader], default=None
-            Load GCP reference data (optional).
+    DATA LOADERS (excluded from JSON serialisation):
+        telemetry_loader, science_loader, gcp_loader
 
-    PROCESSING FUNCTIONS (Optional - will use defaults/stubs if not provided):
-        gcp_pairing_func : Optional[GCPPairingFunc], default=None
-            Spatial pairing of science data to GCP.
-        image_matching_func : Optional[ImageMatchingFunc], default=None
-            Image correlation for errors.
+    PROCESSING FUNCTIONS (excluded from JSON serialisation):
+        gcp_pairing_func, image_matching_func
 
-    OUTPUT CONFIGURATION (Optional - sensible defaults provided):
-        netcdf : Optional[NetCDFConfig], default=None
-            NetCDF metadata (auto-generated if None).
-        output_filename : Optional[str], default=None
-            Output filename (auto-generates with timestamp if None).
+    OUTPUT CONFIGURATION:
+        netcdf : NetCDFConfig | None
+        output_filename : str | None
 
-    CALIBRATION CONFIGURATION (Optional - only needed when image_matching_func uses calibration):
-        calibration_dir : Optional[Path], default=None
-            Directory with LOS vectors, optical PSF, GCP files.
-            Set when using image_matching_func that requires calibration files.
-        calibration_file_names : Optional[dict[str, str]], default=None
-            Mission-specific calibration filenames.
-            Example: {'los_vectors': 'b_HS.mat', 'optical_psf': 'optical_PSF_675nm_upsampled.mat'}
+    CALIBRATION CONFIGURATION:
+        calibration_dir : Path | None
+        calibration_file_names : dict[str, str] | None
 
-    MISSION-SPECIFIC NAMING (Optional - override generic defaults):
-        spacecraft_position_name : str, default="sc_position"
-            Variable name for spacecraft position in output NetCDF.
-        boresight_name : str, default="boresight"
-            Variable name for boresight in output NetCDF.
-        transformation_matrix_name : str, default="t_inst2ref"
-            Variable name for transformation matrix in output NetCDF.
+    MISSION-SPECIFIC NAMING:
+        spacecraft_position_name, boresight_name, transformation_matrix_name
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     # CORE CORRECTION SETTINGS
-    seed: int | None
+    seed: int | None = None
     n_iterations: int
     parameters: list[ParameterConfig]
 
@@ -393,14 +445,14 @@ class CorrectionConfig:
     performance_spec_percent: float
     earth_radius_m: float
 
-    # DATA LOADERS
-    telemetry_loader: TelemetryLoader | None = None
-    science_loader: ScienceLoader | None = None
-    gcp_loader: GCPLoader | None = None
+    # DATA LOADERS – excluded from JSON (not serialisable)
+    telemetry_loader: Any = Field(default=None, exclude=True)
+    science_loader: Any = Field(default=None, exclude=True)
+    gcp_loader: Any = Field(default=None, exclude=True)
 
-    # PROCESSING FUNCTIONS
-    gcp_pairing_func: GCPPairingFunc | None = None
-    image_matching_func: ImageMatchingFunc | None = None
+    # PROCESSING FUNCTIONS – excluded from JSON (not serialisable)
+    gcp_pairing_func: Any = Field(default=None, exclude=True)
+    image_matching_func: Any = Field(default=None, exclude=True)
 
     # OUTPUT CONFIGURATION
     netcdf: NetCDFConfig | None = None
@@ -439,7 +491,6 @@ class CorrectionConfig:
         logger = logging.getLogger(__name__)
         errors = []
 
-        # Check required fields
         if self.n_iterations is None or self.n_iterations <= 0:
             errors.append("n_iterations must be a positive integer")
 
@@ -458,7 +509,6 @@ class CorrectionConfig:
         if self.performance_spec_percent is None or not (0 <= self.performance_spec_percent <= 100):
             errors.append("performance_spec_percent must be between 0 and 100 (e.g., 39.0)")
 
-        # Check required data loaders (Config-Centric Design) - only if requested
         if check_loaders:
             if self.telemetry_loader is None:
                 errors.append(
@@ -482,7 +532,6 @@ class CorrectionConfig:
             error_msg += "\nSee tests/test_correction/clarreo_config.py for an example."
             raise ValueError(error_msg)
 
-        # Check optional processing functions (warnings only) - only if checking loaders
         if check_loaders:
             if self.gcp_pairing_func is None:
                 logger.warning(
@@ -507,40 +556,14 @@ class CorrectionConfig:
             self.netcdf = NetCDFConfig(performance_threshold_m=self.performance_threshold_m)
 
     def get_output_filename(self, default: str = "correction_results.nc") -> str:
-        """
-        Get output filename with optional auto-generation.
-
-        Args:
-            default: Default filename if output_filename is None
-
-        Returns:
-            Filename string (can include timestamp/parameters if configured)
-        """
+        """Get output filename with optional auto-generation."""
         if self.output_filename:
             return self.output_filename
         return default
 
     @staticmethod
     def generate_timestamped_filename(prefix: str = "correction", suffix: str = "") -> str:
-        """
-        Generate a timestamped output filename for production use.
-
-        This prevents overwriting previous results and provides unique identifiers.
-
-        Args:
-            prefix: Filename prefix (e.g., 'correction', 'clarreo_gcs')
-            suffix: Optional suffix before extension (e.g., 'upstream', 'test')
-
-        Returns:
-            Filename with format: {prefix}_YYYYMMDD_HHMMSS[_{suffix}].nc
-
-        Examples:
-            >>> CorrectionConfig.generate_timestamped_filename()
-            'correction_20251029_143022.nc'
-
-            >>> CorrectionConfig.generate_timestamped_filename('clarreo_gcs', 'production')
-            'clarreo_gcs_20251029_143022_production.nc'
-        """
+        """Generate a timestamped output filename for production use."""
         import datetime
 
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -672,8 +695,8 @@ def load_config_from_json(config_path: Path) -> "CorrectionConfig":
             angles = group_data["angles"]
             center_values = [angles.get("roll", 0.0), angles.get("pitch", 0.0), angles.get("yaw", 0.0)]
             param_data = {
-                "center": center_values,
-                "arange": template.get("bounds", [-100, 100]),
+                "current_value": center_values,
+                "bounds": template.get("bounds", [-100, 100]),
                 "sigma": template.get("sigma"),
                 "units": template.get("units", "arcseconds"),
                 "distribution": template.get("distribution_type", "normal"),
@@ -682,8 +705,8 @@ def load_config_from_json(config_path: Path) -> "CorrectionConfig":
         else:
             param_dict = group_data["param_dict"]
             param_data = {
-                "center": param_dict.get("initial_value", 0.0),
-                "arange": param_dict.get("bounds", [-100, 100]),
+                "current_value": param_dict.get("initial_value", 0.0),
+                "bounds": param_dict.get("bounds", [-100, 100]),
                 "sigma": param_dict.get("sigma"),
                 "units": param_dict.get("units", "radians"),
                 "distribution": param_dict.get("distribution_type", "normal"),

--- a/curryer/correction/parameters.py
+++ b/curryer/correction/parameters.py
@@ -51,8 +51,8 @@ def load_param_sets(config: CorrectionConfig) -> list[list[tuple[ParameterConfig
     logger.info(f"Generating {config.n_iterations} parameter sets for {len(config.parameters)} parameters:")
     for i, param in enumerate(config.parameters):
         param_name = param.config_file.name if param.config_file else f"param_{i}"
-        current_value = param.data.get("current_value", param.data.get("center", 0.0))
-        bounds = param.data.get("bounds", param.data.get("arange", [-1.0, 1.0]))
+        current_value = param.data.current_value
+        bounds = param.data.bounds
         logger.info(
             f"  {i + 1}. {param_name} ({param.ptype.name}): "
             f"current_value={current_value}, sigma={param.data.get('sigma', 'N/A')}, "
@@ -64,8 +64,8 @@ def load_param_sets(config: CorrectionConfig) -> list[list[tuple[ParameterConfig
         logger.debug(f"Generating parameter set {ith + 1}/{config.n_iterations}")
 
         for param_idx, param in enumerate(config.parameters):
-            current_value = param.data.get("current_value", param.data.get("center", 0.0))
-            bounds = param.data.get("bounds", param.data.get("arange", [-1.0, 1.0]))
+            current_value = param.data.current_value
+            bounds = param.data.bounds
 
             if param.ptype == ParameterType.CONSTANT_KERNEL:
                 if isinstance(current_value, list) and len(current_value) == 3:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ dependencies = [
     "openpyxl>=3",
     "numpy >=1.23,<2.0",
     "boto3",
-    "typing-extensions"
+    "typing-extensions",
+    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_correction/test_config.py
+++ b/tests/test_correction/test_config.py
@@ -159,20 +159,6 @@ class TestParameterData:
         assert pd.units is None
         assert pd.distribution == "normal"
 
-    # -- legacy alias handling --------------------------------------------------
-
-    def test_legacy_center_alias(self):
-        pd = ParameterData(center=5.0)
-        assert pd.current_value == 5.0
-
-    def test_legacy_arange_alias(self):
-        pd = ParameterData(arange=[-50.0, 50.0])
-        assert pd.bounds == [-50.0, 50.0]
-
-    def test_legacy_aliases_do_not_overwrite_explicit(self):
-        pd = ParameterData(center=5.0, current_value=7.0)
-        assert pd.current_value == 7.0  # explicit wins
-
     # -- dict-style backward compat -------------------------------------------
 
     def test_get_returns_value(self):

--- a/tests/test_correction/test_config.py
+++ b/tests/test_correction/test_config.py
@@ -1,0 +1,576 @@
+"""Tests for the Pydantic-based correction configuration models.
+
+Covers:
+- Construction and field validation for all BaseModel subclasses
+- ``ParameterData`` backward-compatible dict-style access
+- JSON round-trip: ``config == CorrectionConfig.model_validate_json(config.model_dump_json())``
+- ``ValidationError`` raised with field-level messages for invalid inputs
+- Legacy alias handling (``center``/``arange`` → ``current_value``/``bounds``)
+- Callable / loader fields excluded from JSON serialisation
+"""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from curryer.correction.config import (
+    CorrectionConfig,
+    GeolocationConfig,
+    NetCDFConfig,
+    NetCDFParameterMetadata,
+    ParameterConfig,
+    ParameterData,
+    ParameterType,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def geo() -> GeolocationConfig:
+    return GeolocationConfig(
+        meta_kernel_file=Path("tests/data/test.kernels.tm.json"),
+        generic_kernel_dir=Path("data/generic"),
+        dynamic_kernels=[Path("tests/data/sc.spk.json"), Path("tests/data/sc.ck.json")],
+        instrument_name="TEST_INSTRUMENT",
+        time_field="corrected_timestamp",
+    )
+
+
+@pytest.fixture
+def param_constant(geo) -> ParameterConfig:
+    return ParameterConfig(
+        ptype=ParameterType.CONSTANT_KERNEL,
+        config_file=Path("tests/data/test_base.attitude.ck.json"),
+        data={
+            "current_value": [0.0, 0.0, 0.0],
+            "bounds": [-300.0, 300.0],
+            "sigma": 30.0,
+            "units": "arcseconds",
+            "distribution": "normal",
+            "transformation_type": "dcm_rotation",
+            "coordinate_frames": ["FRAME_A", "FRAME_B"],
+        },
+    )
+
+
+@pytest.fixture
+def param_offset_kernel() -> ParameterConfig:
+    return ParameterConfig(
+        ptype=ParameterType.OFFSET_KERNEL,
+        config_file=Path("tests/data/test_az.attitude.ck.json"),
+        data={
+            "field": "hps.az_ang_nonlin",
+            "current_value": 0.0,
+            "bounds": [-300.0, 300.0],
+            "sigma": 30.0,
+            "units": "arcseconds",
+        },
+    )
+
+
+@pytest.fixture
+def param_offset_time() -> ParameterConfig:
+    return ParameterConfig(
+        ptype=ParameterType.OFFSET_TIME,
+        config_file=None,
+        data={
+            "field": "corrected_timestamp",
+            "current_value": 0.0,
+            "bounds": [-50.0, 50.0],
+            "sigma": 7.0,
+            "units": "milliseconds",
+        },
+    )
+
+
+@pytest.fixture
+def netcdf_cfg() -> NetCDFConfig:
+    return NetCDFConfig(
+        performance_threshold_m=250.0,
+        title="Test Geolocation Analysis",
+        description="Unit-test run",
+    )
+
+
+@pytest.fixture
+def minimal_config(geo, param_constant) -> CorrectionConfig:
+    """Minimal CorrectionConfig with no loaders (fully serialisable)."""
+    return CorrectionConfig(
+        seed=42,
+        n_iterations=5,
+        parameters=[param_constant],
+        geo=geo,
+        performance_threshold_m=250.0,
+        performance_spec_percent=39.0,
+        earth_radius_m=6_378_140.0,
+    )
+
+
+@pytest.fixture
+def full_config(geo, param_constant, param_offset_kernel, param_offset_time, netcdf_cfg) -> CorrectionConfig:
+    """Full CorrectionConfig with all optional fields populated."""
+    return CorrectionConfig(
+        seed=0,
+        n_iterations=10,
+        parameters=[param_constant, param_offset_kernel, param_offset_time],
+        geo=geo,
+        performance_threshold_m=250.0,
+        performance_spec_percent=39.0,
+        earth_radius_m=6_378_140.0,
+        netcdf=netcdf_cfg,
+        output_filename="test_results.nc",
+        calibration_dir=Path("tests/data/calibration"),
+        calibration_file_names={"los_vectors": "b_HS.mat", "optical_psf": "psf.mat"},
+        spacecraft_position_name="riss_ctrs",
+        boresight_name="bhat_hs",
+        transformation_matrix_name="t_hs2ctrs",
+    )
+
+
+# ===========================================================================
+# ParameterData – construction and typed fields
+# ===========================================================================
+
+
+class TestParameterData:
+    def test_construction_with_all_fields(self):
+        pd = ParameterData(
+            current_value=[1.0, 2.0, 3.0],
+            bounds=[-100.0, 100.0],
+            sigma=10.0,
+            units="arcseconds",
+            distribution="normal",
+            field="some_field",
+            transformation_type="dcm_rotation",
+            coordinate_frames=["F1", "F2"],
+        )
+        assert pd.current_value == [1.0, 2.0, 3.0]
+        assert pd.sigma == 10.0
+        assert pd.units == "arcseconds"
+
+    def test_defaults(self):
+        pd = ParameterData()
+        assert pd.current_value == 0.0
+        assert pd.sigma is None
+        assert pd.units is None
+        assert pd.distribution == "normal"
+
+    # -- legacy alias handling --------------------------------------------------
+
+    def test_legacy_center_alias(self):
+        pd = ParameterData(center=5.0)
+        assert pd.current_value == 5.0
+
+    def test_legacy_arange_alias(self):
+        pd = ParameterData(arange=[-50.0, 50.0])
+        assert pd.bounds == [-50.0, 50.0]
+
+    def test_legacy_aliases_do_not_overwrite_explicit(self):
+        pd = ParameterData(center=5.0, current_value=7.0)
+        assert pd.current_value == 7.0  # explicit wins
+
+    # -- dict-style backward compat -------------------------------------------
+
+    def test_get_returns_value(self):
+        pd = ParameterData(sigma=30.0, units="arcseconds")
+        assert pd.get("sigma") == 30.0
+        assert pd.get("units") == "arcseconds"
+
+    def test_get_returns_default_for_none_field(self):
+        pd = ParameterData()  # sigma=None by default
+        assert pd.get("sigma", "N/A") == "N/A"
+        assert pd.get("sigma") is None
+
+    def test_get_nonexistent_key_returns_default(self):
+        pd = ParameterData()
+        assert pd.get("no_such_key", "MISSING") == "MISSING"
+
+    def test_contains_true_for_non_none_field(self):
+        pd = ParameterData(sigma=30.0)
+        assert "sigma" in pd
+
+    def test_contains_false_for_none_field(self):
+        pd = ParameterData()  # sigma=None
+        assert "sigma" not in pd
+
+    def test_contains_true_for_zero_sigma(self):
+        """sigma=0.0 is explicitly set and must be found by 'in'."""
+        pd = ParameterData(sigma=0.0)
+        assert "sigma" in pd
+
+    def test_getitem_returns_value(self):
+        pd = ParameterData(sigma=5.0)
+        assert pd["sigma"] == 5.0
+
+    def test_getitem_raises_keyerror_for_missing_key(self):
+        pd = ParameterData()
+        with pytest.raises(KeyError):
+            _ = pd["totally_missing"]
+
+    def test_extra_fields_allowed_and_accessible(self):
+        pd = ParameterData(my_custom_field="hello")
+        assert pd.get("my_custom_field") == "hello"
+        assert "my_custom_field" in pd
+        assert pd["my_custom_field"] == "hello"
+
+    def test_validation_error_for_non_numeric_sigma(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ParameterData(sigma="not-a-float")
+        assert "sigma" in str(exc_info.value)
+
+
+# ===========================================================================
+# ParameterConfig
+# ===========================================================================
+
+
+class TestParameterConfig:
+    def test_dict_coercion(self, param_constant):
+        """Passing data as a plain dict must produce a ParameterData instance."""
+        assert isinstance(param_constant.data, ParameterData)
+        assert param_constant.data.sigma == 30.0
+
+    def test_none_data_becomes_empty_parameter_data(self):
+        """data=None (old API) must be accepted and become a default ParameterData."""
+        pc = ParameterConfig(
+            ptype=ParameterType.CONSTANT_KERNEL,
+            config_file=Path("kernel.json"),
+            data=None,
+        )
+        assert isinstance(pc.data, ParameterData)
+
+    def test_no_config_file(self):
+        pc = ParameterConfig(ptype=ParameterType.OFFSET_TIME, config_file=None)
+        assert pc.config_file is None
+
+    def test_invalid_ptype_raises_validation_error(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ParameterConfig(ptype="INVALID_TYPE", config_file=None)
+        assert "ptype" in str(exc_info.value)
+
+    def test_all_parameter_types_accepted(self):
+        for ptype in ParameterType:
+            pc = ParameterConfig(ptype=ptype)
+            assert pc.ptype == ptype
+
+
+# ===========================================================================
+# GeolocationConfig
+# ===========================================================================
+
+
+class TestGeolocationConfig:
+    def test_basic_construction(self, geo):
+        assert geo.instrument_name == "TEST_INSTRUMENT"
+        assert geo.time_field == "corrected_timestamp"
+        assert len(geo.dynamic_kernels) == 2
+
+    def test_dynamic_kernels_default_empty(self):
+        g = GeolocationConfig(
+            meta_kernel_file=Path("x.json"),
+            generic_kernel_dir=Path("data"),
+            instrument_name="INST",
+            time_field="ts",
+        )
+        assert g.dynamic_kernels == []
+
+    def test_path_fields_coerce_strings(self):
+        g = GeolocationConfig(
+            meta_kernel_file="path/to/mk.json",
+            generic_kernel_dir="data/generic",
+            instrument_name="I",
+            time_field="t",
+        )
+        assert isinstance(g.meta_kernel_file, Path)
+        assert isinstance(g.generic_kernel_dir, Path)
+
+    def test_missing_required_field_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            GeolocationConfig(
+                meta_kernel_file=Path("x.json"),
+                generic_kernel_dir=Path("data"),
+                # instrument_name missing
+                time_field="ts",
+            )
+        assert "instrument_name" in str(exc_info.value)
+
+    def test_minimum_correlation_optional(self, geo):
+        assert geo.minimum_correlation is None
+        geo_with_corr = GeolocationConfig(
+            meta_kernel_file=Path("x.json"),
+            generic_kernel_dir=Path("d"),
+            instrument_name="I",
+            time_field="t",
+            minimum_correlation=0.7,
+        )
+        assert geo_with_corr.minimum_correlation == 0.7
+
+
+# ===========================================================================
+# NetCDFParameterMetadata
+# ===========================================================================
+
+
+class TestNetCDFParameterMetadata:
+    def test_construction(self):
+        m = NetCDFParameterMetadata(
+            variable_name="param_hysics_roll",
+            units="arcseconds",
+            long_name="HySICS roll correction",
+        )
+        assert m.variable_name == "param_hysics_roll"
+
+    def test_missing_field_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            NetCDFParameterMetadata(variable_name="x", units="m")  # long_name missing
+        assert "long_name" in str(exc_info.value)
+
+
+# ===========================================================================
+# NetCDFConfig
+# ===========================================================================
+
+
+class TestNetCDFConfig:
+    def test_threshold_metric_name(self, netcdf_cfg):
+        assert netcdf_cfg.get_threshold_metric_name() == "percent_under_250m"
+
+    def test_threshold_metric_name_round(self):
+        nc = NetCDFConfig(performance_threshold_m=500.0)
+        assert nc.get_threshold_metric_name() == "percent_under_500m"
+
+    def test_get_standard_attributes_defaults(self, netcdf_cfg):
+        attrs = netcdf_cfg.get_standard_attributes()
+        assert "rms_error_m" in attrs
+        assert attrs["rms_error_m"]["units"] == "meters"
+
+    def test_get_standard_attributes_override(self):
+        custom = {"my_var": {"units": "km", "long_name": "My Variable"}}
+        nc = NetCDFConfig(performance_threshold_m=100.0, standard_attributes=custom)
+        assert nc.get_standard_attributes() == custom
+
+    def test_auto_generate_metadata_constant_kernel(self, netcdf_cfg, param_constant):
+        meta = netcdf_cfg.get_parameter_netcdf_metadata(param_constant, angle_type="roll")
+        assert "roll" in meta.long_name
+        assert meta.units == "arcseconds"
+        assert meta.variable_name.startswith("param_")
+
+    def test_auto_generate_metadata_offset_time(self, netcdf_cfg, param_offset_time):
+        meta = netcdf_cfg.get_parameter_netcdf_metadata(param_offset_time)
+        assert meta.units == "milliseconds"
+
+    def test_missing_threshold_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            NetCDFConfig()  # performance_threshold_m required
+        assert "performance_threshold_m" in str(exc_info.value)
+
+
+# ===========================================================================
+# CorrectionConfig
+# ===========================================================================
+
+
+class TestCorrectionConfig:
+    def test_basic_construction(self, minimal_config):
+        assert minimal_config.n_iterations == 5
+        assert minimal_config.seed == 42
+        assert len(minimal_config.parameters) == 1
+
+    def test_callable_fields_default_none(self, minimal_config):
+        assert minimal_config.telemetry_loader is None
+        assert minimal_config.science_loader is None
+        assert minimal_config.gcp_loader is None
+        assert minimal_config.gcp_pairing_func is None
+        assert minimal_config.image_matching_func is None
+
+    def test_callable_fields_can_be_set(self, minimal_config):
+        def my_loader():
+            return None
+
+        minimal_config.telemetry_loader = my_loader
+        assert minimal_config.telemetry_loader is my_loader
+        minimal_config.telemetry_loader = None
+
+    def test_mutable_fields(self, minimal_config):
+        minimal_config.n_iterations = 99
+        assert minimal_config.n_iterations == 99
+        minimal_config.n_iterations = 5
+
+    def test_missing_required_field_raises(self, geo, param_constant):
+        with pytest.raises(ValidationError) as exc_info:
+            CorrectionConfig(
+                n_iterations=5,
+                parameters=[param_constant],
+                geo=geo,
+                # performance_threshold_m missing
+                performance_spec_percent=39.0,
+                earth_radius_m=6_378_140.0,
+            )
+        assert "performance_threshold_m" in str(exc_info.value)
+
+    def test_invalid_n_iterations_type_raises(self, geo, param_constant):
+        with pytest.raises(ValidationError) as exc_info:
+            CorrectionConfig(
+                n_iterations="not-an-int",
+                parameters=[param_constant],
+                geo=geo,
+                performance_threshold_m=250.0,
+                performance_spec_percent=39.0,
+                earth_radius_m=6_378_140.0,
+            )
+        assert "n_iterations" in str(exc_info.value)
+
+    def test_validate_method_passes_for_valid_config(self, minimal_config):
+        minimal_config.validate(check_loaders=False)  # must not raise
+
+    def test_validate_method_raises_for_bad_n_iterations(self, minimal_config):
+        minimal_config.n_iterations = -1
+        with pytest.raises(ValueError, match="n_iterations"):
+            minimal_config.validate()
+        minimal_config.n_iterations = 5
+
+    def test_validate_method_raises_for_missing_loaders(self, minimal_config):
+        with pytest.raises(ValueError, match="telemetry_loader"):
+            minimal_config.validate(check_loaders=True)
+
+    def test_ensure_netcdf_config_creates_default(self, minimal_config):
+        assert minimal_config.netcdf is None
+        minimal_config.ensure_netcdf_config()
+        assert isinstance(minimal_config.netcdf, NetCDFConfig)
+        assert minimal_config.netcdf.performance_threshold_m == 250.0
+
+    def test_ensure_netcdf_config_idempotent(self, minimal_config):
+        minimal_config.ensure_netcdf_config()
+        first = minimal_config.netcdf
+        minimal_config.ensure_netcdf_config()
+        assert minimal_config.netcdf is first  # same object
+
+    def test_get_output_filename_default(self, minimal_config):
+        assert minimal_config.get_output_filename() == "correction_results.nc"
+
+    def test_get_output_filename_custom(self, minimal_config):
+        minimal_config.output_filename = "my_results.nc"
+        assert minimal_config.get_output_filename() == "my_results.nc"
+        minimal_config.output_filename = None
+
+    def test_get_calibration_file(self, full_config):
+        assert full_config.get_calibration_file("los_vectors") == "b_HS.mat"
+
+    def test_get_calibration_file_missing_raises(self, full_config):
+        with pytest.raises(ValueError, match="No calibration file configured"):
+            full_config.get_calibration_file("nonexistent_type")
+
+    def test_get_calibration_file_default_fallback(self, full_config):
+        assert full_config.get_calibration_file("nonexistent_type", default="fallback.mat") == "fallback.mat"
+
+
+# ===========================================================================
+# JSON Round-Trip (acceptance criterion)
+# ===========================================================================
+
+
+class TestJsonRoundTrip:
+    """config == CorrectionConfig.model_validate_json(config.model_dump_json())"""
+
+    def test_minimal_config_roundtrip(self, minimal_config):
+        json_str = minimal_config.model_dump_json()
+        reloaded = CorrectionConfig.model_validate_json(json_str)
+        assert minimal_config == reloaded
+
+    def test_full_config_roundtrip(self, full_config):
+        json_str = full_config.model_dump_json()
+        reloaded = CorrectionConfig.model_validate_json(json_str)
+        assert full_config == reloaded
+
+    def test_callable_fields_excluded_from_json(self, minimal_config):
+        minimal_config.telemetry_loader = lambda: None
+        minimal_config.science_loader = lambda: None
+        minimal_config.gcp_pairing_func = lambda x: x
+        json_str = minimal_config.model_dump_json()
+        assert "telemetry_loader" not in json_str
+        assert "science_loader" not in json_str
+        assert "gcp_pairing_func" not in json_str
+        # clean up
+        minimal_config.telemetry_loader = None
+        minimal_config.science_loader = None
+        minimal_config.gcp_pairing_func = None
+
+    def test_json_contains_expected_keys(self, minimal_config):
+        import json
+
+        data = json.loads(minimal_config.model_dump_json())
+        assert "n_iterations" in data
+        assert "parameters" in data
+        assert "geo" in data
+        assert "performance_threshold_m" in data
+        assert "performance_spec_percent" in data
+        assert "earth_radius_m" in data
+
+    def test_path_fields_survive_roundtrip(self, minimal_config):
+        reloaded = CorrectionConfig.model_validate_json(minimal_config.model_dump_json())
+        assert isinstance(reloaded.geo.meta_kernel_file, Path)
+        assert reloaded.geo.meta_kernel_file == minimal_config.geo.meta_kernel_file
+        assert reloaded.geo.generic_kernel_dir == minimal_config.geo.generic_kernel_dir
+
+    def test_parameter_type_enum_survives_roundtrip(self, full_config):
+        reloaded = CorrectionConfig.model_validate_json(full_config.model_dump_json())
+        for orig, reld in zip(full_config.parameters, reloaded.parameters):
+            assert orig.ptype == reld.ptype
+
+    def test_parameter_data_fields_survive_roundtrip(self, full_config):
+        reloaded = CorrectionConfig.model_validate_json(full_config.model_dump_json())
+        for orig, reld in zip(full_config.parameters, reloaded.parameters):
+            assert orig.data.sigma == reld.data.sigma
+            assert orig.data.units == reld.data.units
+            assert orig.data.bounds == reld.data.bounds
+            assert orig.data.field == reld.data.field
+
+    def test_netcdf_config_survives_roundtrip(self, full_config):
+        reloaded = CorrectionConfig.model_validate_json(full_config.model_dump_json())
+        assert reloaded.netcdf is not None
+        assert reloaded.netcdf.performance_threshold_m == full_config.netcdf.performance_threshold_m
+        assert reloaded.netcdf.title == full_config.netcdf.title
+
+    def test_geo_model_roundtrip_standalone(self, geo):
+        json_str = geo.model_dump_json()
+        reloaded = GeolocationConfig.model_validate_json(json_str)
+        assert geo == reloaded
+
+    def test_netcdf_config_roundtrip_standalone(self, netcdf_cfg):
+        json_str = netcdf_cfg.model_dump_json()
+        reloaded = NetCDFConfig.model_validate_json(json_str)
+        assert netcdf_cfg == reloaded
+
+    def test_parameter_config_roundtrip_standalone(self, param_constant):
+        json_str = param_constant.model_dump_json()
+        reloaded = ParameterConfig.model_validate_json(json_str)
+        assert param_constant == reloaded
+
+    def test_parameter_data_roundtrip_standalone(self):
+        pd = ParameterData(
+            current_value=[1.0, 2.0, 3.0],
+            bounds=[-300.0, 300.0],
+            sigma=30.0,
+            units="arcseconds",
+            coordinate_frames=["F1", "F2"],
+        )
+        reloaded = ParameterData.model_validate_json(pd.model_dump_json())
+        assert pd == reloaded
+
+    def test_roundtrip_with_none_seed(self, geo, param_constant):
+        config = CorrectionConfig(
+            seed=None,
+            n_iterations=3,
+            parameters=[param_constant],
+            geo=geo,
+            performance_threshold_m=100.0,
+            performance_spec_percent=50.0,
+            earth_radius_m=6_378_140.0,
+        )
+        reloaded = CorrectionConfig.model_validate_json(config.model_dump_json())
+        assert reloaded.seed is None
+        assert config == reloaded

--- a/tests/test_correction/test_config.py
+++ b/tests/test_correction/test_config.py
@@ -5,7 +5,6 @@ Covers:
 - ``ParameterData`` backward-compatible dict-style access
 - JSON round-trip: ``config == CorrectionConfig.model_validate_json(config.model_dump_json())``
 - ``ValidationError`` raised with field-level messages for invalid inputs
-- Legacy alias handling (``center``/``arange`` → ``current_value``/``bounds``)
 - Callable / loader fields excluded from JSON serialisation
 """
 


### PR DESCRIPTION
This pull request introduces a few targeted improvements to the parameter handling logic and project dependencies. The main updates include switching from dictionary-style access to attribute-style access for parameter data, and adding `pydantic` as a dependency.

Dependency updates:

* Added `pydantic>=2.0` to the dependencies in `pyproject.toml`, which may be used for data validation or model parsing elsewhere in the codebase.

Parameter data access improvements:

* Updated parameter value access in `curryer/correction/parameters.py` to use attribute-style access (`param.data.current_value` and `param.data.bounds`) instead of dictionary-style access (`param.data.get(...)`). This change improves code readability and may support stricter typing or validation. [[1]](diffhunk://#diff-202f059114c98946062dcbc25b073667285171d2990891b0e503b0c78d6e57f9L54-R55) [[2]](diffhunk://#diff-202f059114c98946062dcbc25b073667285171d2990891b0e503b0c78d6e57f9L67-R68)