### PR TITLE
129 pr 32 add gcp regridding tool

### DIFF
--- a/curryer/correction/__init__.py
+++ b/curryer/correction/__init__.py
@@ -45,12 +45,14 @@ from . import (
     data_structures,
     dataio,
     error_stats,
+    image_io,
     image_match,
     kernel_ops,
     pairing,
     parameters,
     pipeline,
     psf,
+    regrid,
     results_io,
     search,
 )
@@ -67,7 +69,7 @@ from .config import (
     SearchStrategy,
     load_config_from_json,
 )
-from .data_structures import ImageGrid, PSFGrid, PSFSamplingConfig, SearchConfig
+from .data_structures import ImageGrid, PSFGrid, PSFSamplingConfig, RegridConfig, SearchConfig
 from .error_stats import ErrorStatsConfig, ErrorStatsProcessor
 from .pipeline import loop
 
@@ -79,12 +81,14 @@ __all__ = [
     "data_structures",
     "dataio",
     "error_stats",
+    "image_io",
     "image_match",
     "kernel_ops",
     "pairing",
     "parameters",
     "pipeline",
     "psf",
+    "regrid",
     "results_io",
     "search",
     # Config
@@ -103,6 +107,7 @@ __all__ = [
     "ImageGrid",
     "PSFGrid",
     "PSFSamplingConfig",
+    "RegridConfig",
     "SearchConfig",
     # Error stats
     "ErrorStatsConfig",

--- a/curryer/correction/data_structures.py
+++ b/curryer/correction/data_structures.py
@@ -177,7 +177,7 @@ class RegridConfig(BaseModel):
     @classmethod
     def validate_method(cls, v: str) -> str:
         """Validate interpolation method name."""
-        valid = {"bilinear", "nearest", "cubic"}
+        valid = {"bilinear", "nearest"}
         if v not in valid:
             raise ValueError(f"interpolation_method must be one of {valid}, got '{v}'")
         return v

--- a/curryer/correction/data_structures.py
+++ b/curryer/correction/data_structures.py
@@ -139,7 +139,9 @@ class RegridConfig(BaseModel):
     """Configuration for GCP chip regridding.
 
     Specifies output grid parameters for transforming irregular geodetic grids
-    to regular latitude/longitude grids.
+    to regular latitude/longitude grids. ECEF → geodetic conversion always
+    uses the WGS84 ellipsoid, which is the only ellipsoid supported by
+    ``curryer.compute.spatial.ecef_to_geodetic``.
 
     Parameters
     ----------
@@ -160,8 +162,6 @@ class RegridConfig(BaseModel):
         Interpolation method; one of ``"bilinear"`` or ``"nearest"``.
     fill_value : float, default=NaN
         Value assigned to output points that fall outside the input grid.
-    ellipsoid : str, default="WGS84"
-        Reference ellipsoid used for ECEF ↔ geodetic conversions.
     """
 
     output_grid_size: tuple[int, int] | None = None
@@ -170,7 +170,6 @@ class RegridConfig(BaseModel):
     conservative_bounds: bool = True
     interpolation_method: str = "bilinear"
     fill_value: float = float("nan")
-    ellipsoid: str = "WGS84"
 
     @field_validator("interpolation_method")
     @classmethod

--- a/curryer/correction/data_structures.py
+++ b/curryer/correction/data_structures.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
+from pydantic import BaseModel, field_validator, model_validator
 
 
 @dataclass
@@ -132,3 +133,98 @@ class SearchConfig:
     grid_span_km: float = 11.0
     reduction_factor: float = 0.8
     spacing_limit_m: float = 10.0
+
+
+class RegridConfig(BaseModel):
+    """Configuration for GCP chip regridding.
+
+    Specifies output grid parameters for transforming irregular geodetic grids
+    to regular latitude/longitude grids.
+
+    Parameters
+    ----------
+    output_grid_size : tuple[int, int], optional
+        Desired output grid dimensions as (nrows, ncols). Mutually exclusive
+        with ``output_resolution_deg``.
+    output_resolution_deg : tuple[float, float], optional
+        Desired output resolution as (dlat, dlon) in degrees. Mutually
+        exclusive with ``output_grid_size``. Required when ``output_bounds``
+        is set.
+    output_bounds : tuple[float, float, float, float], optional
+        Explicit output grid bounds as (minlon, maxlon, minlat, maxlat) in
+        degrees. Requires ``output_resolution_deg``.
+    conservative_bounds : bool, default=True
+        If True, shrink bounds to ensure all output points lie within the
+        input irregular grid (avoids edge extrapolation).
+    interpolation_method : str, default="bilinear"
+        Interpolation method; one of ``"bilinear"``, ``"nearest"``,
+        or ``"cubic"``.
+    fill_value : float, default=NaN
+        Value assigned to output points that fall outside the input grid.
+    ellipsoid : str, default="WGS84"
+        Reference ellipsoid used for ECEF ↔ geodetic conversions.
+    """
+
+    output_grid_size: tuple[int, int] | None = None
+    output_resolution_deg: tuple[float, float] | None = None
+    output_bounds: tuple[float, float, float, float] | None = None
+    conservative_bounds: bool = True
+    interpolation_method: str = "bilinear"
+    fill_value: float = float("nan")
+    ellipsoid: str = "WGS84"
+
+    @field_validator("interpolation_method")
+    @classmethod
+    def validate_method(cls, v: str) -> str:
+        """Validate interpolation method name."""
+        valid = {"bilinear", "nearest", "cubic"}
+        if v not in valid:
+            raise ValueError(f"interpolation_method must be one of {valid}, got '{v}'")
+        return v
+
+    @field_validator("output_grid_size")
+    @classmethod
+    def validate_grid_size(cls, v: tuple[int, int] | None) -> tuple[int, int] | None:
+        """Validate that grid size has at least 2 rows and 2 columns."""
+        if v is not None:
+            if v[0] < 2:
+                raise ValueError(f"Grid size must have at least 2 rows and 2 columns, got {v}")
+            if v[1] < 2:
+                raise ValueError(f"Grid size must have at least 2 rows and 2 columns, got {v}")
+        return v
+
+    @field_validator("output_resolution_deg")
+    @classmethod
+    def validate_resolution(cls, v: tuple[float, float] | None) -> tuple[float, float] | None:
+        """Validate that resolution values are positive."""
+        if v is not None:
+            if v[0] <= 0 or v[1] <= 0:
+                raise ValueError(f"Resolution values must be positive (dlat, dlon), got {v}")
+        return v
+
+    @field_validator("output_bounds")
+    @classmethod
+    def validate_bounds(cls, v: tuple[float, float, float, float] | None) -> tuple[float, float, float, float] | None:
+        """Validate that bounds are properly ordered."""
+        if v is not None:
+            minlon, maxlon, minlat, maxlat = v
+            if minlon >= maxlon:
+                raise ValueError(f"minlon must be < maxlon, got {minlon} >= {maxlon}")
+            if minlat >= maxlat:
+                raise ValueError(f"minlat must be < maxlat, got {minlat} >= {maxlat}")
+        return v
+
+    @model_validator(mode="after")
+    def validate_grid_spec(self) -> RegridConfig:
+        """Validate that grid specification options are mutually consistent."""
+        has_size = self.output_grid_size is not None
+        has_res = self.output_resolution_deg is not None
+        has_bounds = self.output_bounds is not None
+
+        if has_size and has_res:
+            raise ValueError("Cannot specify both output_grid_size and output_resolution_deg")
+        if has_bounds and not has_res:
+            raise ValueError("output_bounds requires output_resolution_deg")
+        if has_bounds and has_size:
+            raise ValueError("Cannot specify both output_bounds and output_grid_size")
+        return self

--- a/curryer/correction/data_structures.py
+++ b/curryer/correction/data_structures.py
@@ -157,8 +157,7 @@ class RegridConfig(BaseModel):
         If True, shrink bounds to ensure all output points lie within the
         input irregular grid (avoids edge extrapolation).
     interpolation_method : str, default="bilinear"
-        Interpolation method; one of ``"bilinear"``, ``"nearest"``,
-        or ``"cubic"``.
+        Interpolation method; one of ``"bilinear"`` or ``"nearest"``.
     fill_value : float, default=NaN
         Value assigned to output points that fall outside the input grid.
     ellipsoid : str, default="WGS84"

--- a/curryer/correction/image_io.py
+++ b/curryer/correction/image_io.py
@@ -1,0 +1,838 @@
+"""Image I/O utilities for correction pipeline.
+
+This module provides format-agnostic loading and saving of image data
+used in the correction pipeline, including:
+- MATLAB .mat files (legacy test data)
+- HDF files (raw GCP chips)
+- NetCDF files (regridded GCPs, outputs)
+
+All functions work with ImageGrid and related data structures.
+No dependencies on image matching or other correction algorithms.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from .data_structures import ImageGrid, NamedImageGrid, OpticalPSFEntry
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# MATLAB File I/O (migrated from image_match.py)
+# ============================================================================
+
+
+def load_image_grid_from_mat(
+    mat_file: Path, key: str = "subimage", name: str | None = None, as_named: bool = False
+) -> ImageGrid | NamedImageGrid:
+    """
+    Load ImageGrid from MATLAB .mat file.
+
+    Parameters
+    ----------
+    mat_file : Path
+        Path to .mat file.
+    key : str, default="subimage"
+        MATLAB struct key (e.g., "subimage" for L1A, "GCP" for reference).
+    name : str, optional
+        Name for NamedImageGrid. Defaults to file path.
+    as_named : bool, default=False
+        If True, return NamedImageGrid; otherwise return ImageGrid.
+
+    Returns
+    -------
+    ImageGrid or NamedImageGrid
+        Loaded image grid with data, lat, lon, h fields.
+
+    Raises
+    ------
+    FileNotFoundError
+        If mat_file doesn't exist.
+    KeyError
+        If key not found in MATLAB file.
+
+    Examples
+    --------
+    >>> # Load L1A subimage
+    >>> l1a = load_image_grid_from_mat(Path("subimage.mat"), key="subimage")
+    >>> # Load GCP reference
+    >>> gcp = load_image_grid_from_mat(Path("gcp.mat"), key="GCP")
+    """
+    from scipy.io import loadmat
+
+    if not mat_file.exists():
+        raise FileNotFoundError(f"MATLAB file not found: {mat_file}")
+
+    mat_data = loadmat(str(mat_file), squeeze_me=True, struct_as_record=False)
+
+    if key not in mat_data:
+        available_keys = [k for k in mat_data.keys() if not k.startswith("__")]
+        raise KeyError(f"Key '{key}' not found in {mat_file.name}. Available keys: {available_keys}")
+
+    struct = mat_data[key]
+    h = getattr(struct, "h", None)
+
+    # Optimize: loadmat already returns numpy arrays, avoid redundant asarray() calls
+    # ImageGrid.__post_init__ will handle final type conversion
+    grid_kwargs = {
+        "data": struct.data,
+        "lat": struct.lat,
+        "lon": struct.lon,
+        "h": h,
+    }
+
+    if as_named:
+        grid_kwargs["name"] = name or str(mat_file)
+        return NamedImageGrid(**grid_kwargs)
+    else:
+        return ImageGrid(**grid_kwargs)
+
+
+def load_optical_psf_from_mat(mat_file: Path, key: str = "PSF_struct_675nm") -> list[OpticalPSFEntry]:
+    """
+    Load optical PSF entries from MATLAB .mat file.
+
+    Parameters
+    ----------
+    mat_file : Path
+        Path to MATLAB file with PSF data.
+    key : str, default="PSF_struct_675nm"
+        Primary key to try for PSF data.
+
+    Returns
+    -------
+    list[OpticalPSFEntry]
+        Optical PSF samples with data, x, and field_angle arrays.
+
+    Raises
+    ------
+    FileNotFoundError
+        If mat_file doesn't exist.
+    KeyError
+        If no PSF data found with common key names.
+    ValueError
+        If PSF entries missing field angle attribute.
+    """
+    from scipy.io import loadmat
+
+    if not mat_file.exists():
+        raise FileNotFoundError(f"Optical PSF file not found: {mat_file}")
+
+    mat_data = loadmat(str(mat_file), squeeze_me=True, struct_as_record=False)
+
+    # Try common keys in order of preference
+    for try_key in [key, "PSF_struct_675nm", "optical_PSF", "PSF"]:
+        if try_key in mat_data:
+            psf_struct = mat_data[try_key]
+            psf_entries_raw = np.atleast_1d(psf_struct)
+
+            psf_entries = []
+            for entry in psf_entries_raw:
+                # Handle both 'FA' and 'field_angle' attribute names
+                # Check if attribute exists first to avoid NumPy array boolean ambiguity
+                field_angle = getattr(entry, "FA", None)
+                if field_angle is None or (
+                    isinstance(field_angle, list | tuple | np.ndarray) and len(field_angle) == 0
+                ):
+                    # Fallback if FA is missing, None, or empty
+                    field_angle = getattr(entry, "field_angle", None)
+
+                if field_angle is None:
+                    raise ValueError(f"PSF entry missing field angle attribute (tried 'FA' and 'field_angle')")
+
+                # Optimize: loadmat already returns numpy arrays, OpticalPSFEntry.__post_init__ handles conversion
+                # Use np.atleast_1d to ensure 1D arrays efficiently
+                psf_entries.append(
+                    OpticalPSFEntry(
+                        data=entry.data,
+                        x=np.atleast_1d(entry.x).ravel(),
+                        field_angle=np.atleast_1d(field_angle).ravel(),
+                    )
+                )
+
+            logger.info(f"Loaded {len(psf_entries)} optical PSF entries from {mat_file.name}")
+            return psf_entries
+
+    available_keys = [k for k in mat_data.keys() if not k.startswith("__")]
+    raise KeyError(f"No PSF data found in {mat_file.name}. Available keys: {available_keys}")
+
+
+def load_los_vectors_from_mat(mat_file: Path, key: str = "b_HS") -> np.ndarray:
+    """
+    Load line-of-sight vectors from MATLAB .mat file.
+
+    Parameters
+    ----------
+    mat_file : Path
+        Path to MATLAB file with LOS vectors.
+    key : str, default="b_HS"
+        Primary key to try for LOS data.
+
+    Returns
+    -------
+    np.ndarray
+        LOS unit vectors in instrument frame, shape (n_pixels, 3).
+
+    Raises
+    ------
+    FileNotFoundError
+        If mat_file doesn't exist.
+    KeyError
+        If no LOS vectors found with common key names.
+    """
+    from scipy.io import loadmat
+
+    if not mat_file.exists():
+        raise FileNotFoundError(f"LOS vector file not found: {mat_file}")
+
+    mat_data = loadmat(str(mat_file))
+
+    # Try common keys in order of preference
+    for try_key in [key, "b_HS", "los_vectors", "pixel_vectors"]:
+        if try_key in mat_data:
+            los = mat_data[try_key]
+
+            # Ensure shape is (n_pixels, 3) not (3, n_pixels)
+            if los.shape[0] == 3 and los.shape[1] > 3:
+                los = los.T
+
+            logger.info(f"Loaded LOS vectors from {mat_file.name}: shape {los.shape}")
+            return los
+
+    available_keys = [k for k in mat_data.keys() if not k.startswith("__")]
+    raise KeyError(f"No LOS vectors found in {mat_file.name}. Available keys: {available_keys}")
+
+
+# ============================================================================
+# NetCDF File I/O (for regridded chips and general image grids)
+# ============================================================================
+
+
+def save_image_grid_to_netcdf(
+    filepath: Path,
+    image_grid: ImageGrid,
+    metadata: dict[str, str] | None = None,
+    compression: bool = True,
+) -> None:
+    """
+    Save ImageGrid to NetCDF file (CF-1.8 compliant).
+
+    This function can be used for any ImageGrid, including regridded GCP chips,
+    L1A subimages, or other gridded data.
+
+    Parameters
+    ----------
+    filepath : Path
+        Output NetCDF file path.
+    image_grid : ImageGrid
+        Image data with lat/lon coordinates to save.
+    metadata : dict[str, str], optional
+        Additional global attributes to include in the NetCDF file.
+        Common keys: 'source_file', 'mission', 'sensor', 'processing_date', 'band'.
+    compression : bool, default=True
+        Enable zlib compression for data variables (~50% size reduction).
+
+    Raises
+    ------
+    ImportError
+        If netCDF4 is not installed.
+    OSError
+        If file cannot be written.
+
+    Notes
+    -----
+    The NetCDF file follows CF-1.8 conventions and contains:
+    - Variables: 'data', 'latitude', 'longitude', 'height' (if available)
+    - Dimensions: 'y' (rows), 'x' (columns)
+    - Coordinates: latitude(y, x) or (y,), longitude(y, x) or (x,)
+    - Attributes: grid info, CRS metadata, processing information
+
+    For regular grids (1D coordinates), variables are stored efficiently as:
+    - latitude(y): Single column
+    - longitude(x): Single row
+
+    For irregular grids (2D coordinates), full arrays are stored:
+    - latitude(y, x): Full grid
+    - longitude(y, x): Full grid
+
+    Examples
+    --------
+    Save regridded GCP chip:
+
+    >>> save_image_grid_to_netcdf(
+    ...     Path("regridded.nc"),
+    ...     regridded_chip,
+    ...     metadata={
+    ...         'source_file': 'LT08CHP.20140803.p002r071.c01.v001.hdf',
+    ...         'mission': 'CLARREO Pathfinder',
+    ...         'sensor': 'Landsat-8',
+    ...         'band': 'red',
+    ...         'processing_date': '2026-02-02'
+    ...     }
+    ... )
+
+    Save L1A subimage:
+
+    >>> save_image_grid_to_netcdf(
+    ...     Path("l1a_subimage.nc"),
+    ...     l1a_grid,
+    ...     metadata={'mission': 'CLARREO', 'level': 'L1A'}
+    ... )
+    """
+    try:
+        from datetime import datetime
+
+        from netCDF4 import Dataset
+    except ImportError as e:
+        raise ImportError("netCDF4 is required to save NetCDF files. Install with: pip install netCDF4") from e
+
+    filepath = Path(filepath)
+    logger.info(f"Saving ImageGrid to NetCDF: {filepath}")
+
+    # Create NetCDF file
+    with Dataset(filepath, "w", format="NETCDF4") as nc:
+        # Global attributes
+        nc.setncattr("title", "Regridded GCP Chip")
+        nc.setncattr("institution", "NASA Langley Research Center")
+        nc.setncattr("source", "Curryer GCP Regridding Module")
+        nc.setncattr("history", f"Created {datetime.utcnow().isoformat()}Z")
+        nc.setncattr("Conventions", "CF-1.8")
+        nc.setncattr("grid_type", "regular_lat_lon")
+
+        # Add user-provided metadata
+        if metadata:
+            for key, value in metadata.items():
+                nc.setncattr(key, str(value))
+
+        # Create dimensions
+        nrows, ncols = image_grid.data.shape
+        nc.createDimension("y", nrows)
+        nc.createDimension("x", ncols)
+
+        # Compression settings
+        comp_kwargs = {"zlib": True, "complevel": 4} if compression else {}
+
+        # Determine if coordinates are 1D or 2D
+        lat_is_1d = image_grid.lat.ndim == 1 or (
+            image_grid.lat.ndim == 2 and np.allclose(image_grid.lat, image_grid.lat[:, 0:1])
+        )
+        lon_is_1d = image_grid.lon.ndim == 1 or (
+            image_grid.lon.ndim == 2 and np.allclose(image_grid.lon, image_grid.lon[0:1, :])
+        )
+
+        # Create coordinate variables
+        if lat_is_1d:
+            # 1D latitude (varies with y only)
+            lat_var = nc.createVariable("latitude", "f8", ("y",), **comp_kwargs)
+            lat_var[:] = image_grid.lat[:, 0] if image_grid.lat.ndim == 2 else image_grid.lat
+        else:
+            # 2D latitude
+            lat_var = nc.createVariable("latitude", "f8", ("y", "x"), **comp_kwargs)
+            lat_var[:] = image_grid.lat
+
+        lat_var.units = "degrees_north"
+        lat_var.long_name = "latitude"
+        lat_var.standard_name = "latitude"
+
+        if lon_is_1d:
+            # 1D longitude (varies with x only)
+            lon_var = nc.createVariable("longitude", "f8", ("x",), **comp_kwargs)
+            lon_var[:] = image_grid.lon[0, :] if image_grid.lon.ndim == 2 else image_grid.lon
+        else:
+            # 2D longitude
+            lon_var = nc.createVariable("longitude", "f8", ("y", "x"), **comp_kwargs)
+            lon_var[:] = image_grid.lon
+
+        lon_var.units = "degrees_east"
+        lon_var.long_name = "longitude"
+        lon_var.standard_name = "longitude"
+
+        # Create data variable
+        data_var = nc.createVariable("data", "f8", ("y", "x"), fill_value=np.nan, **comp_kwargs)
+        data_var[:] = image_grid.data
+        data_var.long_name = "regridded_radiance"
+        data_var.units = "DN"
+        data_var.coordinates = "latitude longitude"
+        data_var.grid_mapping = "crs"
+
+        # Add grid statistics as attributes
+        data_var.setncattr("valid_min", float(np.nanmin(image_grid.data)))
+        data_var.setncattr("valid_max", float(np.nanmax(image_grid.data)))
+        data_var.setncattr("valid_pixels", int(np.sum(~np.isnan(image_grid.data))))
+
+        # Add height if available
+        if image_grid.h is not None:
+            h_var = nc.createVariable("height", "f8", ("y", "x"), fill_value=np.nan, **comp_kwargs)
+            h_var[:] = image_grid.h
+            h_var.units = "meters"
+            h_var.long_name = "height_above_reference_ellipsoid"
+            h_var.standard_name = "height_above_reference_ellipsoid"
+            h_var.coordinates = "latitude longitude"
+
+        # Add CRS information (WGS84)
+        crs = nc.createVariable("crs", "i4")
+        crs.grid_mapping_name = "latitude_longitude"
+        crs.semi_major_axis = 6378137.0
+        crs.inverse_flattening = 298.257223563
+        crs.long_name = "WGS84"
+        crs.crs_wkt = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]'
+
+    logger.info(f"NetCDF file saved successfully: {filepath} ({filepath.stat().st_size / 1024:.1f} KB)")
+
+
+def load_image_grid_from_netcdf(filepath: Path) -> ImageGrid:
+    """
+    Load ImageGrid from NetCDF file.
+
+    Loads regridded GCP chips or other gridded data saved in NetCDF format.
+    Automatically handles both 1D and 2D coordinate arrays.
+
+    Parameters
+    ----------
+    filepath : Path
+        Input NetCDF file path.
+
+    Returns
+    -------
+    ImageGrid
+        Loaded image grid with data, lat, lon, and h (if available).
+
+    Raises
+    ------
+    ImportError
+        If netCDF4 is not installed.
+    FileNotFoundError
+        If filepath doesn't exist.
+    KeyError
+        If required variables not found in file.
+
+    Examples
+    --------
+    >>> regridded = load_image_grid_from_netcdf(Path("regridded.nc"))
+    >>> regridded.data.shape
+    (421, 433)
+    """
+    try:
+        from netCDF4 import Dataset
+    except ImportError as e:
+        raise ImportError("netCDF4 is required to load NetCDF files. Install with: pip install netCDF4") from e
+
+    filepath = Path(filepath)
+
+    if not filepath.exists():
+        raise FileNotFoundError(f"NetCDF file not found: {filepath}")
+
+    logger.info(f"Loading ImageGrid from NetCDF: {filepath}")
+
+    with Dataset(filepath, "r") as nc:
+        # Load data
+        if "data" not in nc.variables:
+            raise KeyError(f"Required variable 'data' not found in {filepath.name}")
+        data = nc.variables["data"][:]
+
+        # Load coordinates
+        if "latitude" not in nc.variables:
+            raise KeyError(f"Required variable 'latitude' not found in {filepath.name}")
+        if "longitude" not in nc.variables:
+            raise KeyError(f"Required variable 'longitude' not found in {filepath.name}")
+
+        lat_var = nc.variables["latitude"]
+        lon_var = nc.variables["longitude"]
+
+        # Handle 1D or 2D coordinates
+        if lat_var.ndim == 1:
+            # Expand 1D to 2D
+            lat_1d = lat_var[:]
+            lon_1d = lon_var[:]
+            lon, lat = np.meshgrid(lon_1d, lat_1d)
+        else:
+            lat = lat_var[:]
+            lon = lon_var[:]
+
+        # Load height if available
+        h = nc.variables["height"][:] if "height" in nc.variables else None
+
+    logger.info(f"Loaded ImageGrid from NetCDF: shape {data.shape}")
+    return ImageGrid(data=data, lat=lat, lon=lon, h=h)
+
+
+# ============================================================================
+# HDF File I/O (new for regridding)
+# ============================================================================
+
+
+def load_gcp_chip_from_hdf(
+    filepath: Path,
+    band_name: str = "Band_1",
+    coord_names: tuple[str, str, str] = (
+        "ECR_x_coordinate_array",
+        "ECR_y_coordinate_array",
+        "ECR_z_coordinate_array",
+    ),
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Load raw GCP chip data from HDF file (Landsat format).
+
+    Supports both HDF4 and HDF5 formats. Tries HDF4 first (Landsat standard),
+    then falls back to HDF5 if needed.
+
+    Parameters
+    ----------
+    filepath : Path
+        Path to HDF file containing GCP chip data.
+    band_name : str, default="Band_1"
+        Name of the dataset containing band/radiometric data.
+    coord_names : tuple[str, str, str], default=("ECR_x_coordinate_array", ...)
+        Names of X, Y, Z coordinate datasets (ECEF coordinates in meters).
+
+    Returns
+    -------
+    band_data : np.ndarray
+        2D array of radiometric values, shape (nrows, ncols).
+    ecef_x, ecef_y, ecef_z : np.ndarray
+        2D arrays of ECEF coordinates in meters, each shape (nrows, ncols).
+
+    Raises
+    ------
+    FileNotFoundError
+        If filepath doesn't exist.
+    KeyError
+        If required datasets not found in HDF file.
+    ValueError
+        If array shapes are inconsistent.
+
+    Examples
+    --------
+    >>> band, x, y, z = load_gcp_chip_from_hdf("LT08CHP.20140803.hdf")
+    >>> band.shape
+    (1400, 1400)
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"HDF file not found: {filepath}")
+
+    coord_x_name, coord_y_name, coord_z_name = coord_names
+
+    # Try HDF4 first (Landsat standard format)
+    try:
+        from pyhdf.SD import SD, SDC
+
+        hdf = SD(str(filepath), SDC.READ)
+        datasets = hdf.datasets()
+
+        # Check for required datasets
+        if band_name not in datasets:
+            available = list(datasets.keys())
+            hdf.end()
+            raise KeyError(f"Band '{band_name}' not found. Available datasets: {available}")
+
+        if coord_x_name not in datasets:
+            hdf.end()
+            raise KeyError(f"X coordinate '{coord_x_name}' not found in {filepath.name}")
+        if coord_y_name not in datasets:
+            hdf.end()
+            raise KeyError(f"Y coordinate '{coord_y_name}' not found in {filepath.name}")
+        if coord_z_name not in datasets:
+            hdf.end()
+            raise KeyError(f"Z coordinate '{coord_z_name}' not found in {filepath.name}")
+
+        # Load datasets
+        band_data = np.array(hdf.select(band_name).get(), dtype=np.float64)
+        ecef_x = np.array(hdf.select(coord_x_name).get(), dtype=np.float64)
+        ecef_y = np.array(hdf.select(coord_y_name).get(), dtype=np.float64)
+        ecef_z = np.array(hdf.select(coord_z_name).get(), dtype=np.float64)
+
+        hdf.end()
+
+        logger.info(f"Loaded GCP chip from HDF4 file {filepath.name}: shape {band_data.shape}")
+
+    except ImportError:
+        # HDF4 library not available, try HDF5
+        try:
+            import h5py
+
+            with h5py.File(filepath, "r") as hdf:
+                # Load band data
+                if band_name not in hdf:
+                    available = list(hdf.keys())
+                    raise KeyError(f"Band '{band_name}' not found. Available datasets: {available}")
+
+                band_data = np.array(hdf[band_name], dtype=np.float64)
+
+                # Load ECEF coordinates
+                if coord_x_name not in hdf:
+                    raise KeyError(f"X coordinate '{coord_x_name}' not found in {filepath.name}")
+                if coord_y_name not in hdf:
+                    raise KeyError(f"Y coordinate '{coord_y_name}' not found in {filepath.name}")
+                if coord_z_name not in hdf:
+                    raise KeyError(f"Z coordinate '{coord_z_name}' not found in {filepath.name}")
+
+                ecef_x = np.array(hdf[coord_x_name], dtype=np.float64)
+                ecef_y = np.array(hdf[coord_y_name], dtype=np.float64)
+                ecef_z = np.array(hdf[coord_z_name], dtype=np.float64)
+
+            logger.info(f"Loaded GCP chip from HDF5 file {filepath.name}: shape {band_data.shape}")
+
+        except (ImportError, OSError) as e:
+            raise ImportError(
+                f"Cannot read HDF file {filepath}. "
+                f"Neither pyhdf (for HDF4) nor h5py (for HDF5) could open the file. "
+                f"Error: {e}"
+            ) from e
+
+    # Validate shapes
+    if not (band_data.shape == ecef_x.shape == ecef_y.shape == ecef_z.shape):
+        raise ValueError(
+            f"Array shape mismatch in {filepath.name}: "
+            f"band={band_data.shape}, x={ecef_x.shape}, y={ecef_y.shape}, z={ecef_z.shape}"
+        )
+
+    return band_data, ecef_x, ecef_y, ecef_z
+
+
+def load_gcp_chip_from_netcdf(
+    filepath: Path,
+    band_var: str = "band_data",
+    lat_var: str = "lat",
+    lon_var: str = "lon",
+    height_var: str = "h",
+) -> ImageGrid:
+    """
+    Load regridded GCP chip from NetCDF file.
+
+    Parameters
+    ----------
+    filepath : Path
+        Path to NetCDF file.
+    band_var : str, default="band_data"
+        Name of the band data variable.
+    lat_var : str, default="lat"
+        Name of the latitude variable.
+    lon_var : str, default="lon"
+        Name of the longitude variable.
+    height_var : str, default="h"
+        Name of the height variable (optional).
+
+    Returns
+    -------
+    ImageGrid
+        Loaded image grid with data, lat, lon, h fields.
+
+    Raises
+    ------
+    FileNotFoundError
+        If filepath doesn't exist.
+    KeyError
+        If required variables not found.
+
+    Examples
+    --------
+    >>> gcp = load_gcp_chip_from_netcdf("regridded_chip.nc")
+    >>> gcp.data.shape
+    (420, 420)
+    """
+    import xarray as xr
+
+    if not filepath.exists():
+        raise FileNotFoundError(f"NetCDF file not found: {filepath}")
+
+    try:
+        ds = xr.open_dataset(filepath)
+
+        # Check required variables
+        if band_var not in ds:
+            raise KeyError(f"Band variable '{band_var}' not found in {filepath.name}")
+        if lat_var not in ds:
+            raise KeyError(f"Latitude variable '{lat_var}' not found in {filepath.name}")
+        if lon_var not in ds:
+            raise KeyError(f"Longitude variable '{lon_var}' not found in {filepath.name}")
+
+        # Load data
+        data = ds[band_var].values
+        lat = ds[lat_var].values
+        lon = ds[lon_var].values
+        h = ds[height_var].values if height_var in ds else None
+
+        ds.close()
+
+    except Exception as e:
+        raise OSError(f"Error reading NetCDF file {filepath}: {e}") from e
+
+    logger.info(f"Loaded GCP chip from {filepath.name}: shape {data.shape}")
+
+    return ImageGrid(data=data, lat=lat, lon=lon, h=h)
+
+
+# ============================================================================
+# Generic Image Savers (new for regridding + general use)
+# ============================================================================
+
+
+def save_image_grid(
+    filepath: Path,
+    image_grid: ImageGrid,
+    format: str = "netcdf",
+    metadata: dict | None = None,
+) -> None:
+    """
+    Save ImageGrid to file (netcdf, mat, or geotiff).
+
+    This function works with any ImageGrid, not just regridded GCPs.
+    It can be used throughout the correction pipeline.
+
+    Parameters
+    ----------
+    filepath : Path
+        Output file path.
+    image_grid : ImageGrid
+        Image data with lat/lon coordinates.
+    format : str, default="netcdf"
+        Output format: 'netcdf', 'mat', or 'geotiff'.
+    metadata : dict, optional
+        Additional metadata to include in output.
+
+    Raises
+    ------
+    ValueError
+        If format is not supported.
+    IOError
+        If file cannot be written.
+
+    Examples
+    --------
+    >>> save_image_grid("output.nc", regridded_gcp, format="netcdf")
+    >>> save_image_grid("output.mat", regridded_gcp, format="mat")
+    """
+    format = format.lower()
+
+    if format == "netcdf":
+        _save_image_grid_netcdf(filepath, image_grid, metadata)
+    elif format == "mat":
+        _save_image_grid_mat(filepath, image_grid, metadata)
+    elif format == "geotiff":
+        _save_image_grid_geotiff(filepath, image_grid, metadata)
+    else:
+        raise ValueError(f"Unsupported format: {format}. Supported: 'netcdf', 'mat', 'geotiff'")
+
+    logger.info(f"Saved ImageGrid to {filepath} (format: {format})")
+
+
+def _save_image_grid_netcdf(filepath: Path, image_grid: ImageGrid, metadata: dict | None) -> None:
+    """Save ImageGrid to NetCDF file (internal helper)."""
+    import xarray as xr
+
+    # Create xarray Dataset
+    nrows, ncols = image_grid.data.shape
+
+    ds = xr.Dataset(
+        {
+            "band_data": (["y", "x"], image_grid.data),
+            "lat": (["y", "x"], image_grid.lat),
+            "lon": (["y", "x"], image_grid.lon),
+        },
+        coords={
+            "y": np.arange(nrows),
+            "x": np.arange(ncols),
+        },
+    )
+
+    # Add height if present
+    if image_grid.h is not None:
+        ds["h"] = (["y", "x"], image_grid.h)
+
+    # Add metadata
+    if metadata:
+        ds.attrs.update(metadata)
+
+    # Add standard attributes
+    ds.attrs["title"] = "Regridded GCP Chip"
+    ds.attrs["Conventions"] = "CF-1.8"
+
+    # Add variable attributes
+    ds["band_data"].attrs["long_name"] = "Band radiometric data"
+    ds["band_data"].attrs["units"] = "digital_number"
+    ds["lat"].attrs["long_name"] = "Latitude"
+    ds["lat"].attrs["units"] = "degrees_north"
+    ds["lon"].attrs["long_name"] = "Longitude"
+    ds["lon"].attrs["units"] = "degrees_east"
+
+    if "h" in ds:
+        ds["h"].attrs["long_name"] = "Height above ellipsoid"
+        ds["h"].attrs["units"] = "meters"
+
+    # Write to file
+    try:
+        ds.to_netcdf(filepath, engine="netcdf4")
+    except Exception as e:
+        raise OSError(f"Error writing NetCDF file {filepath}: {e}") from e
+
+
+def _save_image_grid_mat(filepath: Path, image_grid: ImageGrid, metadata: dict | None) -> None:
+    """Save ImageGrid to MATLAB .mat file (internal helper)."""
+    from scipy.io import savemat
+
+    # Prepare data structure
+    mat_dict = {
+        "data": image_grid.data,
+        "lat": image_grid.lat,
+        "lon": image_grid.lon,
+    }
+
+    if image_grid.h is not None:
+        mat_dict["h"] = image_grid.h
+
+    if metadata:
+        mat_dict["metadata"] = metadata
+
+    # Write to file
+    try:
+        savemat(filepath, {"GCP": mat_dict}, do_compression=True)
+    except Exception as e:
+        raise OSError(f"Error writing MAT file {filepath}: {e}") from e
+
+
+def _save_image_grid_geotiff(filepath: Path, image_grid: ImageGrid, metadata: dict | None) -> None:
+    """Save ImageGrid to GeoTIFF file (internal helper)."""
+    try:
+        import rasterio
+        from rasterio.transform import from_bounds
+    except ImportError as e:
+        raise ImportError("GeoTIFF export requires 'rasterio'. Install with: pip install rasterio") from e
+
+    nrows, ncols = image_grid.data.shape
+
+    # Compute geographic bounds
+    minlon = image_grid.lon.min()
+    maxlon = image_grid.lon.max()
+    minlat = image_grid.lat.min()
+    maxlat = image_grid.lat.max()
+
+    # Create affine transform
+    transform = from_bounds(minlon, minlat, maxlon, maxlat, ncols, nrows)
+
+    # Write to file
+    try:
+        with rasterio.open(
+            filepath,
+            "w",
+            driver="GTiff",
+            height=nrows,
+            width=ncols,
+            count=1,
+            dtype=image_grid.data.dtype,
+            crs="EPSG:4326",  # WGS84
+            transform=transform,
+            compress="lzw",
+        ) as dst:
+            dst.write(image_grid.data, 1)
+
+            # Add metadata as tags
+            if metadata:
+                dst.update_tags(**metadata)
+
+    except Exception as e:
+        raise OSError(f"Error writing GeoTIFF file {filepath}: {e}") from e

--- a/curryer/correction/image_io.py
+++ b/curryer/correction/image_io.py
@@ -436,19 +436,22 @@ def load_image_grid_from_netcdf(filepath: Path) -> ImageGrid:
     logger.info(f"Loading ImageGrid from NetCDF: {filepath}")
 
     with Dataset(filepath, "r") as nc:
-        # Load data
-        if "data" not in nc.variables:
+        # Load data — try canonical name first, then legacy name
+        data_name = next((n for n in ("band_data", "data") if n in nc.variables), None)
+        if data_name is None:
             raise KeyError(f"Required variable 'data' not found in {filepath.name}")
-        data = nc.variables["data"][:]
+        data = nc.variables[data_name][:]
 
-        # Load coordinates
-        if "latitude" not in nc.variables:
+        # Load coordinates — try canonical names first, then legacy names
+        lat_name = next((n for n in ("lat", "latitude") if n in nc.variables), None)
+        lon_name = next((n for n in ("lon", "longitude") if n in nc.variables), None)
+        if lat_name is None:
             raise KeyError(f"Required variable 'latitude' not found in {filepath.name}")
-        if "longitude" not in nc.variables:
+        if lon_name is None:
             raise KeyError(f"Required variable 'longitude' not found in {filepath.name}")
 
-        lat_var = nc.variables["latitude"]
-        lon_var = nc.variables["longitude"]
+        lat_var = nc.variables[lat_name]
+        lon_var = nc.variables[lon_name]
 
         # Handle 1D or 2D coordinates
         if lat_var.ndim == 1:
@@ -460,8 +463,9 @@ def load_image_grid_from_netcdf(filepath: Path) -> ImageGrid:
             lat = lat_var[:]
             lon = lon_var[:]
 
-        # Load height if available
-        h = nc.variables["height"][:] if "height" in nc.variables else None
+        # Load height if available — try canonical name first, then legacy name
+        h_name = next((n for n in ("h", "height") if n in nc.variables), None)
+        h = nc.variables[h_name][:] if h_name is not None else None
 
     logger.info(f"Loaded ImageGrid from NetCDF: shape {data.shape}")
     return ImageGrid(data=data, lat=lat, lon=lon, h=h)

--- a/curryer/correction/image_io.py
+++ b/curryer/correction/image_io.py
@@ -300,7 +300,9 @@ def save_image_grid_to_netcdf(
         nc.setncattr("title", "Regridded GCP Chip")
         nc.setncattr("institution", "NASA Langley Research Center")
         nc.setncattr("source", "Curryer GCP Regridding Module")
-        nc.setncattr("history", f"Created {datetime.datetime.now(datetime.UTC).isoformat()}Z")
+        nc.setncattr(
+            "history", f"Created {datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}"
+        )
         nc.setncattr("Conventions", "CF-1.8")
         nc.setncattr("grid_type", "regular_lat_lon")
 

--- a/curryer/correction/image_io.py
+++ b/curryer/correction/image_io.py
@@ -285,7 +285,7 @@ def save_image_grid_to_netcdf(
     ... )
     """
     try:
-        from datetime import datetime
+        import datetime
 
         from netCDF4 import Dataset
     except ImportError as e:
@@ -300,7 +300,7 @@ def save_image_grid_to_netcdf(
         nc.setncattr("title", "Regridded GCP Chip")
         nc.setncattr("institution", "NASA Langley Research Center")
         nc.setncattr("source", "Curryer GCP Regridding Module")
-        nc.setncattr("history", f"Created {datetime.utcnow().isoformat()}Z")
+        nc.setncattr("history", f"Created {datetime.datetime.now(datetime.UTC).isoformat()}Z")
         nc.setncattr("Conventions", "CF-1.8")
         nc.setncattr("grid_type", "regular_lat_lon")
 

--- a/curryer/correction/image_io.py
+++ b/curryer/correction/image_io.py
@@ -247,18 +247,18 @@ def save_image_grid_to_netcdf(
     Notes
     -----
     The NetCDF file follows CF-1.8 conventions and contains:
-    - Variables: 'data', 'latitude', 'longitude', 'height' (if available)
+    - Variables: 'band_data', 'lat', 'lon', 'h' (if available)
     - Dimensions: 'y' (rows), 'x' (columns)
-    - Coordinates: latitude(y, x) or (y,), longitude(y, x) or (x,)
+    - Coordinates: lat(y, x) or (y,), lon(y, x) or (x,)
     - Attributes: grid info, CRS metadata, processing information
 
     For regular grids (1D coordinates), variables are stored efficiently as:
-    - latitude(y): Single column
-    - longitude(x): Single row
+    - lat(y): Single column
+    - lon(x): Single row
 
     For irregular grids (2D coordinates), full arrays are stored:
-    - latitude(y, x): Full grid
-    - longitude(y, x): Full grid
+    - lat(y, x): Full grid
+    - lon(y, x): Full grid
 
     Examples
     --------
@@ -328,13 +328,14 @@ def save_image_grid_to_netcdf(
         )
 
         # Create coordinate variables
+        # Variable names match load_gcp_chip_from_netcdf defaults: lat, lon, band_data, h
         if lat_is_1d:
             # 1D latitude (varies with y only)
-            lat_var = nc.createVariable("latitude", "f8", ("y",), **comp_kwargs)
+            lat_var = nc.createVariable("lat", "f8", ("y",), **comp_kwargs)
             lat_var[:] = image_grid.lat[:, 0] if image_grid.lat.ndim == 2 else image_grid.lat
         else:
             # 2D latitude
-            lat_var = nc.createVariable("latitude", "f8", ("y", "x"), **comp_kwargs)
+            lat_var = nc.createVariable("lat", "f8", ("y", "x"), **comp_kwargs)
             lat_var[:] = image_grid.lat
 
         lat_var.units = "degrees_north"
@@ -343,11 +344,11 @@ def save_image_grid_to_netcdf(
 
         if lon_is_1d:
             # 1D longitude (varies with x only)
-            lon_var = nc.createVariable("longitude", "f8", ("x",), **comp_kwargs)
+            lon_var = nc.createVariable("lon", "f8", ("x",), **comp_kwargs)
             lon_var[:] = image_grid.lon[0, :] if image_grid.lon.ndim == 2 else image_grid.lon
         else:
             # 2D longitude
-            lon_var = nc.createVariable("longitude", "f8", ("y", "x"), **comp_kwargs)
+            lon_var = nc.createVariable("lon", "f8", ("y", "x"), **comp_kwargs)
             lon_var[:] = image_grid.lon
 
         lon_var.units = "degrees_east"
@@ -355,11 +356,11 @@ def save_image_grid_to_netcdf(
         lon_var.standard_name = "longitude"
 
         # Create data variable
-        data_var = nc.createVariable("data", "f8", ("y", "x"), fill_value=np.nan, **comp_kwargs)
+        data_var = nc.createVariable("band_data", "f8", ("y", "x"), fill_value=np.nan, **comp_kwargs)
         data_var[:] = image_grid.data
         data_var.long_name = "regridded_radiance"
         data_var.units = "DN"
-        data_var.coordinates = "latitude longitude"
+        data_var.coordinates = "lat lon"
         data_var.grid_mapping = "crs"
 
         # Add grid statistics as attributes
@@ -372,12 +373,12 @@ def save_image_grid_to_netcdf(
 
         # Add height if available
         if image_grid.h is not None:
-            h_var = nc.createVariable("height", "f8", ("y", "x"), fill_value=np.nan, **comp_kwargs)
+            h_var = nc.createVariable("h", "f8", ("y", "x"), fill_value=np.nan, **comp_kwargs)
             h_var[:] = image_grid.h
             h_var.units = "meters"
             h_var.long_name = "height_above_reference_ellipsoid"
             h_var.standard_name = "height_above_reference_ellipsoid"
-            h_var.coordinates = "latitude longitude"
+            h_var.coordinates = "lat lon"
 
         # Add CRS information (WGS84)
         crs = nc.createVariable("crs", "i4")

--- a/curryer/correction/image_io.py
+++ b/curryer/correction/image_io.py
@@ -361,9 +361,12 @@ def save_image_grid_to_netcdf(
         data_var.grid_mapping = "crs"
 
         # Add grid statistics as attributes
-        data_var.setncattr("valid_min", float(np.nanmin(image_grid.data)))
-        data_var.setncattr("valid_max", float(np.nanmax(image_grid.data)))
-        data_var.setncattr("valid_pixels", int(np.sum(~np.isnan(image_grid.data))))
+        valid_mask = ~np.isnan(image_grid.data)
+        valid_pixels = int(np.sum(valid_mask))
+        data_var.setncattr("valid_pixels", valid_pixels)
+        if valid_pixels > 0:
+            data_var.setncattr("valid_min", float(np.nanmin(image_grid.data)))
+            data_var.setncattr("valid_max", float(np.nanmax(image_grid.data)))
 
         # Add height if available
         if image_grid.h is not None:

--- a/curryer/correction/image_match.py
+++ b/curryer/correction/image_match.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -189,7 +190,11 @@ def integrated_image_match(
 
 
 # ============================================================================
-# MATLAB File Loading Utilities
+# MATLAB File Loading Utilities — Deprecation Shims
+#
+# These functions have been moved to curryer.correction.image_io.
+# They are kept here for backward compatibility and will be removed in a
+# future release.
 # ============================================================================
 
 
@@ -199,176 +204,51 @@ def load_image_grid_from_mat(
     """
     Load ImageGrid from MATLAB .mat file.
 
-    Parameters
-    ----------
-    mat_file : Path
-        Path to .mat file.
-    key : str, default="subimage"
-        MATLAB struct key (e.g., "subimage" for L1A, "GCP" for reference).
-    name : str, optional
-        Name for NamedImageGrid. Defaults to file path.
-    as_named : bool, default=False
-        If True, return NamedImageGrid; otherwise return ImageGrid.
-
-    Returns
-    -------
-    ImageGrid or NamedImageGrid
-        Loaded image grid with data, lat, lon, h fields.
-
-    Raises
-    ------
-    FileNotFoundError
-        If mat_file doesn't exist.
-    KeyError
-        If key not found in MATLAB file.
-
-    Examples
-    --------
-    >>> # Load L1A subimage
-    >>> l1a = load_image_grid_from_mat(Path("subimage.mat"), key="subimage")
-    >>> # Load GCP reference
-    >>> gcp = load_image_grid_from_mat(Path("gcp.mat"), key="GCP")
+    .. deprecated::
+        Use :func:`curryer.correction.image_io.load_image_grid_from_mat` instead.
     """
-    from scipy.io import loadmat
+    warnings.warn(
+        "load_image_grid_from_mat has moved to curryer.correction.image_io. "
+        "Importing from image_match is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from .image_io import load_image_grid_from_mat as _impl
 
-    if not mat_file.exists():
-        raise FileNotFoundError(f"MATLAB file not found: {mat_file}")
-
-    mat_data = loadmat(str(mat_file), squeeze_me=True, struct_as_record=False)
-
-    if key not in mat_data:
-        available_keys = [k for k in mat_data.keys() if not k.startswith("__")]
-        raise KeyError(f"Key '{key}' not found in {mat_file.name}. Available keys: {available_keys}")
-
-    struct = mat_data[key]
-    h = getattr(struct, "h", None)
-
-    # Optimize: loadmat already returns numpy arrays, avoid redundant asarray() calls
-    # ImageGrid.__post_init__ will handle final type conversion
-    grid_kwargs = {
-        "data": struct.data,
-        "lat": struct.lat,
-        "lon": struct.lon,
-        "h": h,
-    }
-
-    if as_named:
-        grid_kwargs["name"] = name or str(mat_file)
-        return NamedImageGrid(**grid_kwargs)
-    else:
-        return ImageGrid(**grid_kwargs)
+    return _impl(mat_file, key=key, name=name, as_named=as_named)
 
 
 def load_optical_psf_from_mat(mat_file: Path, key: str = "PSF_struct_675nm") -> list[OpticalPSFEntry]:
     """
     Load optical PSF entries from MATLAB .mat file.
 
-    Parameters
-    ----------
-    mat_file : Path
-        Path to MATLAB file with PSF data.
-    key : str, default="PSF_struct_675nm"
-        Primary key to try for PSF data.
-
-    Returns
-    -------
-    list[OpticalPSFEntry]
-        Optical PSF samples with data, x, and field_angle arrays.
-
-    Raises
-    ------
-    FileNotFoundError
-        If mat_file doesn't exist.
-    KeyError
-        If no PSF data found with common key names.
-    ValueError
-        If PSF entries missing field angle attribute.
+    .. deprecated::
+        Use :func:`curryer.correction.image_io.load_optical_psf_from_mat` instead.
     """
-    from scipy.io import loadmat
+    warnings.warn(
+        "load_optical_psf_from_mat has moved to curryer.correction.image_io. "
+        "Importing from image_match is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from .image_io import load_optical_psf_from_mat as _impl
 
-    if not mat_file.exists():
-        raise FileNotFoundError(f"Optical PSF file not found: {mat_file}")
-
-    mat_data = loadmat(str(mat_file), squeeze_me=True, struct_as_record=False)
-
-    # Try common keys in order of preference
-    for try_key in [key, "PSF_struct_675nm", "optical_PSF", "PSF"]:
-        if try_key in mat_data:
-            psf_struct = mat_data[try_key]
-            psf_entries_raw = np.atleast_1d(psf_struct)
-
-            psf_entries = []
-            for entry in psf_entries_raw:
-                # Handle both 'FA' and 'field_angle' attribute names
-                # Check if attribute exists first to avoid NumPy array boolean ambiguity
-                field_angle = getattr(entry, "FA", None)
-                if field_angle is None or (
-                    isinstance(field_angle, list | tuple | np.ndarray) and len(field_angle) == 0
-                ):
-                    # Fallback if FA is missing, None, or empty
-                    field_angle = getattr(entry, "field_angle", None)
-
-                if field_angle is None:
-                    raise ValueError(f"PSF entry missing field angle attribute (tried 'FA' and 'field_angle')")
-
-                # Optimize: loadmat already returns numpy arrays, OpticalPSFEntry.__post_init__ handles conversion
-                # Use np.atleast_1d to ensure 1D arrays efficiently
-                psf_entries.append(
-                    OpticalPSFEntry(
-                        data=entry.data,
-                        x=np.atleast_1d(entry.x).ravel(),
-                        field_angle=np.atleast_1d(field_angle).ravel(),
-                    )
-                )
-
-            logger.info(f"Loaded {len(psf_entries)} optical PSF entries from {mat_file.name}")
-            return psf_entries
-
-    available_keys = [k for k in mat_data.keys() if not k.startswith("__")]
-    raise KeyError(f"No PSF data found in {mat_file.name}. Available keys: {available_keys}")
+    return _impl(mat_file, key=key)
 
 
 def load_los_vectors_from_mat(mat_file: Path, key: str = "b_HS") -> np.ndarray:
     """
     Load line-of-sight vectors from MATLAB .mat file.
 
-    Parameters
-    ----------
-    mat_file : Path
-        Path to MATLAB file with LOS vectors.
-    key : str, default="b_HS"
-        Primary key to try for LOS data.
-
-    Returns
-    -------
-    np.ndarray
-        LOS unit vectors in instrument frame, shape (n_pixels, 3).
-
-    Raises
-    ------
-    FileNotFoundError
-        If mat_file doesn't exist.
-    KeyError
-        If no LOS vectors found with common key names.
+    .. deprecated::
+        Use :func:`curryer.correction.image_io.load_los_vectors_from_mat` instead.
     """
-    from scipy.io import loadmat
+    warnings.warn(
+        "load_los_vectors_from_mat has moved to curryer.correction.image_io. "
+        "Importing from image_match is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from .image_io import load_los_vectors_from_mat as _impl
 
-    if not mat_file.exists():
-        raise FileNotFoundError(f"LOS vector file not found: {mat_file}")
-
-    mat_data = loadmat(str(mat_file))
-
-    # Try common keys in order of preference
-    for try_key in [key, "b_HS", "los_vectors", "pixel_vectors"]:
-        if try_key in mat_data:
-            los = mat_data[try_key]
-
-            # Ensure shape is (n_pixels, 3) not (3, n_pixels)
-            if los.shape[0] == 3 and los.shape[1] > 3:
-                los = los.T
-
-            logger.info(f"Loaded LOS vectors from {mat_file.name}: shape {los.shape}")
-            return los
-
-    available_keys = [k for k in mat_data.keys() if not k.startswith("__")]
-    raise KeyError(f"No LOS vectors found in {mat_file.name}. Available keys: {available_keys}")
+    return _impl(mat_file, key=key)

--- a/curryer/correction/pairing.py
+++ b/curryer/correction/pairing.py
@@ -454,7 +454,7 @@ def pair_files(
         >>> for l1a, gcp in pairs:
         ...     print(f"  {l1a.name} → {gcp.name}")
     """
-    from .image_match import load_image_grid_from_mat
+    from .image_io import load_image_grid_from_mat
 
     gcp_dir = Path(gcp_directory)
     if not gcp_dir.is_dir():

--- a/curryer/correction/pipeline.py
+++ b/curryer/correction/pipeline.py
@@ -43,11 +43,13 @@ from curryer.correction.dataio import (
     validate_science_output,
     validate_telemetry_output,
 )
-from curryer.correction.image_match import (
-    integrated_image_match,
+from curryer.correction.image_io import (
     load_image_grid_from_mat,
     load_los_vectors_from_mat,
     load_optical_psf_from_mat,
+)
+from curryer.correction.image_match import (
+    integrated_image_match,
     validate_image_matching_output,
 )
 from curryer.correction.kernel_ops import (

--- a/curryer/correction/regrid.py
+++ b/curryer/correction/regrid.py
@@ -457,20 +457,14 @@ def regrid_irregular_to_regular(
                 center_lat = 0.25 * (lat00 + lat01 + lat10 + lat11)
 
                 # (n_cells, 2) array of [lon, lat] centers
-                cell_centers = np.stack(
-                    [center_lon.ravel(), center_lat.ravel()], axis=-1
-                )
+                cell_centers = np.stack([center_lon.ravel(), center_lat.ravel()], axis=-1)
 
                 # Corresponding (row, col) indices for each cell
                 row_idx, col_idx = np.indices((nrows_in - 1, ncols_in - 1))
-                cell_indices_map = list(
-                    zip(row_idx.ravel(), col_idx.ravel())
-                )
+                cell_indices_map = list(zip(row_idx.ravel(), col_idx.ravel()))
 
                 kdtree = cKDTree(cell_centers)
-                logger.debug(
-                    f"Built spatial index with {len(cell_indices_map)} cells"
-                )
+                logger.debug(f"Built spatial index with {len(cell_indices_map)} cells")
             else:
                 # Grid too small to form any cells
                 kdtree = None

--- a/curryer/correction/regrid.py
+++ b/curryer/correction/regrid.py
@@ -432,38 +432,48 @@ def regrid_irregular_to_regular(
     # Build spatial index if enabled (speeds up cell finding for large grids)
     kdtree = None
     cell_centers = None
-    if use_spatial_index and lon_irregular.shape[0] > 50:
+    # Use total grid size rather than only row count to gate KD-tree construction.
+    # The threshold of 2500 corresponds to a 50x50 grid.
+    if use_spatial_index and lon_irregular.size > 2500:
         try:
             from scipy.spatial import cKDTree
 
-            # Compute cell centers for spatial index
+            # Compute cell centers for spatial index using vectorized operations
             nrows_in, ncols_in = lon_irregular.shape
-            cell_centers_list = []
-            cell_indices_list = []
+            if nrows_in > 1 and ncols_in > 1:
+                # Four corners of each input cell for longitude
+                lon00 = lon_irregular[:-1, :-1]
+                lon01 = lon_irregular[:-1, 1:]
+                lon10 = lon_irregular[1:, :-1]
+                lon11 = lon_irregular[1:, 1:]
+                # Four corners of each input cell for latitude
+                lat00 = lat_irregular[:-1, :-1]
+                lat01 = lat_irregular[:-1, 1:]
+                lat10 = lat_irregular[1:, :-1]
+                lat11 = lat_irregular[1:, 1:]
 
-            for i in range(nrows_in - 1):
-                for j in range(ncols_in - 1):
-                    # Cell center (approximate)
-                    center_lon = 0.25 * (
-                        lon_irregular[i, j]
-                        + lon_irregular[i, j + 1]
-                        + lon_irregular[i + 1, j]
-                        + lon_irregular[i + 1, j + 1]
-                    )
-                    center_lat = 0.25 * (
-                        lat_irregular[i, j]
-                        + lat_irregular[i, j + 1]
-                        + lat_irregular[i + 1, j]
-                        + lat_irregular[i + 1, j + 1]
-                    )
-                    cell_centers_list.append([center_lon, center_lat])
-                    cell_indices_list.append((i, j))
+                # Cell center (approximate) for all cells at once
+                center_lon = 0.25 * (lon00 + lon01 + lon10 + lon11)
+                center_lat = 0.25 * (lat00 + lat01 + lat10 + lat11)
 
-            cell_centers = np.array(cell_centers_list)
-            cell_indices_map = cell_indices_list
-            kdtree = cKDTree(cell_centers)
-            logger.debug(f"Built spatial index with {len(cell_indices_map)} cells")
+                # (n_cells, 2) array of [lon, lat] centers
+                cell_centers = np.stack(
+                    [center_lon.ravel(), center_lat.ravel()], axis=-1
+                )
 
+                # Corresponding (row, col) indices for each cell
+                row_idx, col_idx = np.indices((nrows_in - 1, ncols_in - 1))
+                cell_indices_map = list(
+                    zip(row_idx.ravel(), col_idx.ravel())
+                )
+
+                kdtree = cKDTree(cell_centers)
+                logger.debug(
+                    f"Built spatial index with {len(cell_indices_map)} cells"
+                )
+            else:
+                # Grid too small to form any cells
+                kdtree = None
         except ImportError:
             logger.debug("scipy.spatial.cKDTree not available, using sequential search")
             kdtree = None

--- a/curryer/correction/regrid.py
+++ b/curryer/correction/regrid.py
@@ -115,14 +115,16 @@ def create_regular_grid(
         dlon = (maxlon - minlon) / (ncols - 1)
     else:
         dlat, dlon = resolution
-        nrows = int((maxlat - minlat) / dlat) + 1
-        ncols = int((maxlon - minlon) / dlon) + 1
+        nrows = round((maxlat - minlat) / dlat) + 1
+        ncols = round((maxlon - minlon) / dlon) + 1
 
-    # Create 1D coordinate arrays
-    # Latitude: starts at maxlat (north) and decreases
-    lat_1d = maxlat - np.arange(nrows) * dlat
-    # Longitude: starts at minlon (west) and increases
-    lon_1d = minlon + np.arange(ncols) * dlon
+    # Create 1D coordinate arrays using linspace so that the endpoints are
+    # exact regardless of floating-point accumulation in step arithmetic.
+    # (Using arange-based approach risks the last element overshooting the
+    # bound by a tiny amount, placing output points just outside the input
+    # grid and producing spurious NaN fill values at the edges.)
+    lat_1d = np.linspace(maxlat, minlat, nrows)  # north → south
+    lon_1d = np.linspace(minlon, maxlon, ncols)  # west  → east
 
     # Create 2D meshgrid
     lon_regular, lat_regular = np.meshgrid(lon_1d, lat_1d)
@@ -504,11 +506,12 @@ def regrid_irregular_to_regular(
                 cell = find_containing_cell(point, lon_irregular, lat_irregular, last_cell)
 
             # If windowed search failed or no hint, use spatial index
+            nearest_fallback_cell = None  # track for boundary-snap fallback
             if cell is None and kdtree is not None:
                 # Query k nearest neighbors to find containing cell
                 distances, indices = kdtree.query(point, k=min(9, len(cell_centers)))
 
-                for idx in indices:
+                for rank, idx in enumerate(indices):
                     candidate_i, candidate_j = cell_indices_map[idx]
                     # Direct check if point is in this candidate cell (fast)
                     if _check_point_in_cell(
@@ -516,14 +519,29 @@ def regrid_irregular_to_regular(
                     ):
                         cell = (candidate_i, candidate_j)
                         break
+                    # Remember the geometrically nearest cell in case all strict
+                    # tests fail (boundary-snap fallback, see below).
+                    if rank == 0:
+                        nearest_fallback_cell = (candidate_i, candidate_j)
 
             # Last resort: full search (only if no spatial index available)
             if cell is None and kdtree is None:
                 cell = find_containing_cell(point, lon_irregular, lat_irregular, None)
 
             if cell is None:
-                # Point outside irregular grid, leave as fill_value
-                continue
+                # Boundary-snap fallback: the point may be marginally outside the
+                # input grid due to floating-point differences between the output
+                # bounds (e.g. from MATLAB) and Python's ECEF-to-geodetic results.
+                # Use the nearest cell (slight extrapolation) rather than NaN so
+                # that sub-pixel boundary mismatches don't create artefacts.
+                if nearest_fallback_cell is not None:
+                    cell = nearest_fallback_cell
+                    logger.debug(
+                        f"Boundary snap at [{ii},{jj}] (lon={point_lon:.7f}, lat={point_lat:.7f}) → cell {cell}"
+                    )
+                else:
+                    # Genuinely outside the grid – leave as fill_value
+                    continue
 
             i, j = cell
 

--- a/curryer/correction/regrid.py
+++ b/curryer/correction/regrid.py
@@ -343,6 +343,7 @@ def find_containing_cell(
             j=j,
             tol=tol,
         )
+
     # Determine search start
     if start_cell is not None:
         start_i = max(0, min(start_cell[0] - 1, max_i - 1))

--- a/curryer/correction/regrid.py
+++ b/curryer/correction/regrid.py
@@ -333,38 +333,16 @@ def find_containing_cell(
     tol = 1e-10
 
     def check_cell(i: int, j: int) -> bool:
-        """Check if point is in cell [i,j]. Optimized inline version."""
-        # Get corner coordinates (avoid array allocation)
-        lon_tl, lat_tl = lon_grid[i, j], lat_grid[i, j]
-        lon_tr, lat_tr = lon_grid[i, j + 1], lat_grid[i, j + 1]
-        lon_br, lat_br = lon_grid[i + 1, j + 1], lat_grid[i + 1, j + 1]
-        lon_bl, lat_bl = lon_grid[i + 1, j], lat_grid[i + 1, j]
-
-        # Test upper-left triangle (TL, TR, BL)
-        # Inline barycentric coordinate calculation
-        d_ul = (lon_tl - lon_bl) * (lat_tr - lat_bl) - (lat_tl - lat_bl) * (lon_tr - lon_bl)
-
-        if abs(d_ul) > 1e-14:
-            wA = ((point_lon - lon_bl) * (lat_tr - lat_bl) - (point_lat - lat_bl) * (lon_tr - lon_bl)) / d_ul
-            wB = ((lon_tl - lon_bl) * (point_lat - lat_bl) - (lat_tl - lat_bl) * (point_lon - lon_bl)) / d_ul
-            wC = 1.0 - wA - wB
-
-            if (-tol <= wA <= 1 + tol) and (-tol <= wB <= 1 + tol) and (-tol <= wC <= 1 + tol):
-                return True
-
-        # Test lower-right triangle (TR, BR, BL)
-        d_lr = (lon_tr - lon_bl) * (lat_br - lat_bl) - (lat_tr - lat_bl) * (lon_br - lon_bl)
-
-        if abs(d_lr) > 1e-14:
-            wA = ((point_lon - lon_bl) * (lat_br - lat_bl) - (point_lat - lat_bl) * (lon_br - lon_bl)) / d_lr
-            wB = ((lon_tr - lon_bl) * (point_lat - lat_bl) - (lat_tr - lat_bl) * (point_lon - lon_bl)) / d_lr
-            wC = 1.0 - wA - wB
-
-            if (-tol <= wA <= 1 + tol) and (-tol <= wB <= 1 + tol) and (-tol <= wC <= 1 + tol):
-                return True
-
-        return False
-
+        """Check if point is in cell [i,j] by delegating to the shared helper."""
+        return _check_point_in_cell(
+            lon_grid=lon_grid,
+            lat_grid=lat_grid,
+            point_lon=point_lon,
+            point_lat=point_lat,
+            i=i,
+            j=j,
+            tol=tol,
+        )
     # Determine search start
     if start_cell is not None:
         start_i = max(0, min(start_cell[0] - 1, max_i - 1))

--- a/curryer/correction/regrid.py
+++ b/curryer/correction/regrid.py
@@ -330,7 +330,6 @@ def find_containing_cell(
     max_i, max_j = nrows - 1, ncols - 1
 
     point_lon, point_lat = point[0], point[1]
-    tol = 1e-10
 
     def check_cell(i: int, j: int) -> bool:
         """Check if point is in cell [i,j] by delegating to the shared helper."""
@@ -341,7 +340,6 @@ def find_containing_cell(
             point_lat=point_lat,
             i=i,
             j=j,
-            tol=tol,
         )
 
     # Determine search start

--- a/curryer/correction/regrid.py
+++ b/curryer/correction/regrid.py
@@ -559,7 +559,9 @@ def regrid_irregular_to_regular(
             val_bl = data_irregular[i + 1, j]
 
             # Interpolate
-            if method == "bilinear":
+            if method not in ("bilinear", "nearest"):
+                raise ValueError(f"Unsupported interpolation method: {method!r}")
+            elif method == "bilinear":
                 # Inline bilinear interpolation (avoid function call overhead)
                 # Build interpolation matrix (4x4) and solve
                 M = np.array(

--- a/curryer/correction/regrid.py
+++ b/curryer/correction/regrid.py
@@ -1,0 +1,751 @@
+"""GCP chip regridding algorithms.
+
+This module provides functionality to transform GCP chips from irregular
+geodetic grids (derived from ECEF coordinates) to regular latitude/longitude
+grids. The regridding process is mission-agnostic and configurable via RegridConfig.
+
+The main workflow is:
+1. Load raw GCP chip with ECEF coordinates (from HDF file)
+2. Convert ECEF → geodetic (lon, lat, h)
+3. Determine output grid bounds and spacing
+4. Interpolate data onto regular grid using bilinear interpolation
+5. Return ImageGrid with regular lat/lon coordinates
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from ..compute.spatial import ecef_to_geodetic
+from .data_structures import ImageGrid, RegridConfig
+
+logger = logging.getLogger(__name__)
+
+
+def compute_regular_grid_bounds(
+    lon_irregular: np.ndarray,
+    lat_irregular: np.ndarray,
+    conservative: bool = True,
+) -> tuple[float, float, float, float]:
+    """
+    Compute bounds for regular output grid from irregular input.
+
+    Parameters
+    ----------
+    lon_irregular, lat_irregular : np.ndarray
+        2D arrays of irregular grid coordinates (degrees).
+    conservative : bool, default=True
+        If True, shrink bounds to ensure all output points are within input.
+        Conservative bounds avoid extrapolation at edges by taking the maximum
+        of left/bottom edges and minimum of right/top edges.
+
+    Returns
+    -------
+    minlon, maxlon, minlat, maxlat : float
+        Bounding box for regular grid (degrees).
+
+    Notes
+    -----
+    Conservative bounds (default) follow MATLAB behavior:
+    - minlon = max(bottom_left_lon, top_left_lon)
+    - maxlon = min(bottom_right_lon, top_right_lon)
+    - minlat = max(bottom_left_lat, bottom_right_lat)
+    - maxlat = min(top_left_lat, top_right_lat)
+
+    This ensures the regular grid lies entirely within the irregular grid.
+    """
+    if conservative:
+        # Get corner coordinates (assuming row increases south, col increases east)
+        # Corners: [0,0]=top_left, [0,-1]=top_right, [-1,0]=bottom_left, [-1,-1]=bottom_right
+        minlon = max(lon_irregular[-1, 0], lon_irregular[0, 0])  # bottom-left, top-left
+        maxlon = min(lon_irregular[0, -1], lon_irregular[-1, -1])  # top-right, bottom-right
+        minlat = max(lat_irregular[-1, 0], lat_irregular[-1, -1])  # bottom corners
+        maxlat = min(lat_irregular[0, 0], lat_irregular[0, -1])  # top corners
+    else:
+        # Use full extent
+        minlon = float(lon_irregular.min())
+        maxlon = float(lon_irregular.max())
+        minlat = float(lat_irregular.min())
+        maxlat = float(lat_irregular.max())
+
+    return minlon, maxlon, minlat, maxlat
+
+
+def create_regular_grid(
+    bounds: tuple[float, float, float, float],
+    grid_size: tuple[int, int] | None = None,
+    resolution: tuple[float, float] | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Create regular lat/lon grid.
+
+    Parameters
+    ----------
+    bounds : tuple[float, float, float, float]
+        (minlon, maxlon, minlat, maxlat) in degrees.
+    grid_size : tuple[int, int], optional
+        (nrows, ncols). If None, derive from resolution.
+    resolution : tuple[float, float], optional
+        (dlat, dlon) in degrees. If None, use grid_size.
+
+    Returns
+    -------
+    lon_regular, lat_regular : np.ndarray
+        2D arrays of regular grid coordinates (degrees), shape (nrows, ncols).
+
+    Notes
+    -----
+    Exactly one of grid_size or resolution must be provided.
+    Grid follows MATLAB convention:
+    - Row index increases going south (latitude decreases)
+    - Column index increases going east (longitude increases)
+    """
+    minlon, maxlon, minlat, maxlat = bounds
+
+    if grid_size is not None and resolution is not None:
+        raise ValueError("Specify only one of grid_size or resolution, not both")
+    if grid_size is None and resolution is None:
+        raise ValueError("Must specify either grid_size or resolution")
+
+    if grid_size is not None:
+        nrows, ncols = grid_size
+        dlat = (maxlat - minlat) / (nrows - 1)
+        dlon = (maxlon - minlon) / (ncols - 1)
+    else:
+        dlat, dlon = resolution
+        nrows = int((maxlat - minlat) / dlat) + 1
+        ncols = int((maxlon - minlon) / dlon) + 1
+
+    # Create 1D coordinate arrays
+    # Latitude: starts at maxlat (north) and decreases
+    lat_1d = maxlat - np.arange(nrows) * dlat
+    # Longitude: starts at minlon (west) and increases
+    lon_1d = minlon + np.arange(ncols) * dlon
+
+    # Create 2D meshgrid
+    lon_regular, lat_regular = np.meshgrid(lon_1d, lat_1d)
+
+    logger.debug(f"Created regular grid: {nrows}×{ncols}, resolution: ({dlat:.6f}°, {dlon:.6f}°)")
+
+    return lon_regular, lat_regular
+
+
+def _cross2(a: np.ndarray, b: np.ndarray) -> float:
+    """2D cross product: a[0]*b[1] - a[1]*b[0]."""
+    return a[0] * b[1] - a[1] * b[0]
+
+
+def point_in_triangle(
+    point: np.ndarray,
+    triangle: np.ndarray,
+) -> tuple[bool, np.ndarray]:
+    """
+    Check if point is inside triangle using barycentric coordinates.
+
+    Parameters
+    ----------
+    point : np.ndarray
+        Point [x, y] to test.
+    triangle : np.ndarray
+        Triangle vertices, shape (3, 2): [[x1, y1], [x2, y2], [x3, y3]].
+
+    Returns
+    -------
+    inside : bool
+        True if point is inside triangle (barycentric coords all in (0, 1)).
+    barycentric_coords : np.ndarray
+        Barycentric coordinates [w1, w2, w3].
+
+    Notes
+    -----
+    Uses the cross product method from MATLAB bandval function.
+    Point P is inside triangle ABC if all barycentric weights are in (0, 1).
+    """
+    A, B, C = triangle
+
+    # Compute denominator (area of triangle * 2)
+    # MATLAB: d=cross2(A,B)+cross2(B,C)+cross2(C,A)
+    d = _cross2(A - C, B - C)  # Simplified: same as above
+
+    if abs(d) < 1e-14:  # Degenerate triangle
+        return False, np.array([0.0, 0.0, 0.0])
+
+    # Compute barycentric coordinates following MATLAB bandval logic
+    # MATLAB: wA=(cross2(B,C)+cross2(P,B-C))/d
+    wA = _cross2(point - C, B - C) / d
+    wB = _cross2(A - C, point - C) / d
+    wC = 1.0 - wA - wB
+
+    # Check if point is inside (all weights in [0, 1])
+    # Use small tolerance for boundary cases
+    # MATLAB uses strict inequalities (0 < w < 1), but for numerical stability
+    # and to handle edge cases in regridding, we use tolerant checks
+    tol = 1e-10
+    inside = (-tol <= wA <= 1 + tol) and (-tol <= wB <= 1 + tol) and (-tol <= wC <= 1 + tol)
+
+    return inside, np.array([wA, wB, wC])
+
+
+def bilinear_interpolate_quad(
+    point: np.ndarray,
+    corners_lon: np.ndarray,
+    corners_lat: np.ndarray,
+    corner_values: np.ndarray,
+) -> float:
+    """
+    Bilinear interpolation within an irregular quadrilateral.
+
+    Parameters
+    ----------
+    point : np.ndarray
+        Target point [lon, lat] (degrees).
+    corners_lon, corners_lat : np.ndarray
+        Coordinates of 4 corners, ordered clockwise from top-left:
+        [top-left, top-right, bottom-right, bottom-left].
+    corner_values : np.ndarray
+        Values at the 4 corners.
+
+    Returns
+    -------
+    interpolated_value : float
+        Interpolated value at target point.
+
+    Notes
+    -----
+    Uses matrix inversion method from MATLAB code:
+    Solves [1, lon, lat, lon*lat]^T = M * [w1, w2, w3, w4]^T
+    where M is constructed from corner coordinates.
+    """
+    lon_p, lat_p = point
+
+    # Build interpolation matrix (4x4)
+    # M = [[1,    1,    1,    1   ]
+    #      [lon1, lon2, lon3, lon4]
+    #      [lat1, lat2, lat3, lat4]
+    #      [lon1*lat1, lon2*lat2, lon3*lat3, lon4*lat4]]
+    M = np.ones((4, 4))
+    M[1, :] = corners_lon
+    M[2, :] = corners_lat
+    M[3, :] = corners_lon * corners_lat
+
+    # Right-hand side vector
+    E = np.array([1.0, lon_p, lat_p, lon_p * lat_p])
+
+    # Solve for weights
+    try:
+        weights = np.linalg.solve(M, E)
+    except np.linalg.LinAlgError:
+        # Singular matrix - degenerate quadrilateral
+        # Fall back to simple average
+        logger.warning("Singular matrix in bilinear interpolation, using average")
+        return float(np.mean(corner_values))
+
+    # Compute interpolated value
+    value = np.dot(weights, corner_values)
+
+    return float(value)
+
+
+def _check_point_in_cell(
+    point_lon: float,
+    point_lat: float,
+    lon_grid: np.ndarray,
+    lat_grid: np.ndarray,
+    i: int,
+    j: int,
+) -> bool:
+    """Fast check if point is in cell [i,j]. Returns True/False."""
+    tol = 1e-10
+
+    # Get corner coordinates
+    lon_tl, lat_tl = lon_grid[i, j], lat_grid[i, j]
+    lon_tr, lat_tr = lon_grid[i, j + 1], lat_grid[i, j + 1]
+    lon_br, lat_br = lon_grid[i + 1, j + 1], lat_grid[i + 1, j + 1]
+    lon_bl, lat_bl = lon_grid[i + 1, j], lat_grid[i + 1, j]
+
+    # Test upper-left triangle (TL, TR, BL)
+    d_ul = (lon_tl - lon_bl) * (lat_tr - lat_bl) - (lat_tl - lat_bl) * (lon_tr - lon_bl)
+
+    if abs(d_ul) > 1e-14:
+        wA = ((point_lon - lon_bl) * (lat_tr - lat_bl) - (point_lat - lat_bl) * (lon_tr - lon_bl)) / d_ul
+        wB = ((lon_tl - lon_bl) * (point_lat - lat_bl) - (lat_tl - lat_bl) * (point_lon - lon_bl)) / d_ul
+        wC = 1.0 - wA - wB
+
+        if (-tol <= wA <= 1 + tol) and (-tol <= wB <= 1 + tol) and (-tol <= wC <= 1 + tol):
+            return True
+
+    # Test lower-right triangle (TR, BR, BL)
+    d_lr = (lon_tr - lon_bl) * (lat_br - lat_bl) - (lat_tr - lat_bl) * (lon_br - lon_bl)
+
+    if abs(d_lr) > 1e-14:
+        wA = ((point_lon - lon_bl) * (lat_br - lat_bl) - (point_lat - lat_bl) * (lon_br - lon_bl)) / d_lr
+        wB = ((lon_tr - lon_bl) * (point_lat - lat_bl) - (lat_tr - lat_bl) * (point_lon - lon_bl)) / d_lr
+        wC = 1.0 - wA - wB
+
+        if (-tol <= wA <= 1 + tol) and (-tol <= wB <= 1 + tol) and (-tol <= wC <= 1 + tol):
+            return True
+
+    return False
+
+
+def find_containing_cell(
+    point: np.ndarray,
+    lon_grid: np.ndarray,
+    lat_grid: np.ndarray,
+    start_cell: tuple[int, int] | None = None,
+) -> tuple[int, int] | None:
+    """
+    Find which cell in irregular grid contains the target point.
+
+    Parameters
+    ----------
+    point : np.ndarray
+        Target point [lon, lat] (degrees).
+    lon_grid, lat_grid : np.ndarray
+        2D arrays of irregular grid coordinates (degrees).
+    start_cell : tuple[int, int], optional
+        Starting cell (i, j) for search (optimization hint).
+
+    Returns
+    -------
+    cell_indices : tuple[int, int] or None
+        (i, j) of cell containing point, or None if not found.
+
+    Notes
+    -----
+    Uses barycentric coordinate test to check if point is inside
+    quadrilateral. For each cell, tests two triangles (upper-left and
+    lower-right) that together form the quadrilateral.
+
+    Search strategy follows MATLAB optimization:
+    - Start from hint if provided
+    - Check cells near last found cell (spatial locality)
+    - If not found, search all cells
+
+    Optimization: Inline triangle test to avoid array allocations.
+    """
+    nrows, ncols = lon_grid.shape
+    max_i, max_j = nrows - 1, ncols - 1
+
+    point_lon, point_lat = point[0], point[1]
+    tol = 1e-10
+
+    def check_cell(i: int, j: int) -> bool:
+        """Check if point is in cell [i,j]. Optimized inline version."""
+        # Get corner coordinates (avoid array allocation)
+        lon_tl, lat_tl = lon_grid[i, j], lat_grid[i, j]
+        lon_tr, lat_tr = lon_grid[i, j + 1], lat_grid[i, j + 1]
+        lon_br, lat_br = lon_grid[i + 1, j + 1], lat_grid[i + 1, j + 1]
+        lon_bl, lat_bl = lon_grid[i + 1, j], lat_grid[i + 1, j]
+
+        # Test upper-left triangle (TL, TR, BL)
+        # Inline barycentric coordinate calculation
+        d_ul = (lon_tl - lon_bl) * (lat_tr - lat_bl) - (lat_tl - lat_bl) * (lon_tr - lon_bl)
+
+        if abs(d_ul) > 1e-14:
+            wA = ((point_lon - lon_bl) * (lat_tr - lat_bl) - (point_lat - lat_bl) * (lon_tr - lon_bl)) / d_ul
+            wB = ((lon_tl - lon_bl) * (point_lat - lat_bl) - (lat_tl - lat_bl) * (point_lon - lon_bl)) / d_ul
+            wC = 1.0 - wA - wB
+
+            if (-tol <= wA <= 1 + tol) and (-tol <= wB <= 1 + tol) and (-tol <= wC <= 1 + tol):
+                return True
+
+        # Test lower-right triangle (TR, BR, BL)
+        d_lr = (lon_tr - lon_bl) * (lat_br - lat_bl) - (lat_tr - lat_bl) * (lon_br - lon_bl)
+
+        if abs(d_lr) > 1e-14:
+            wA = ((point_lon - lon_bl) * (lat_br - lat_bl) - (point_lat - lat_bl) * (lon_br - lon_bl)) / d_lr
+            wB = ((lon_tr - lon_bl) * (point_lat - lat_bl) - (lat_tr - lat_bl) * (point_lon - lon_bl)) / d_lr
+            wC = 1.0 - wA - wB
+
+            if (-tol <= wA <= 1 + tol) and (-tol <= wB <= 1 + tol) and (-tol <= wC <= 1 + tol):
+                return True
+
+        return False
+
+    # Determine search start
+    if start_cell is not None:
+        start_i = max(0, min(start_cell[0] - 1, max_i - 1))
+        start_j = max(0, min(start_cell[1] - 1, max_j - 1))
+
+        # Search in a small window around hint first
+        window_size = 3
+        for di in range(-window_size, window_size + 1):
+            for dj in range(-window_size, window_size + 1):
+                i = start_i + di
+                j = start_j + dj
+                if 0 <= i < max_i and 0 <= j < max_j:
+                    if check_cell(i, j):
+                        return (i, j)
+
+        # Not found in window - return None (caller will use spatial index or expand search)
+        return None
+    else:
+        # No hint provided - do full search (only happens for very first point or edge cases)
+        # This is expensive but necessary for correctness when no hint is available
+        for i in range(max_i):
+            for j in range(max_j):
+                if check_cell(i, j):
+                    return (i, j)
+
+    # Not found
+    return None
+
+
+def regrid_irregular_to_regular(
+    data_irregular: np.ndarray,
+    lon_irregular: np.ndarray,
+    lat_irregular: np.ndarray,
+    lon_regular: np.ndarray,
+    lat_regular: np.ndarray,
+    method: str = "bilinear",
+    fill_value: float = np.nan,
+    use_spatial_index: bool = True,
+) -> np.ndarray:
+    """
+    Regrid data from irregular geodetic grid to regular lat/lon grid.
+
+    This is the core algorithm: for each point in the regular output grid,
+    find the corresponding quadrilateral cell in the irregular input grid
+    and interpolate the value.
+
+    Parameters
+    ----------
+    data_irregular : np.ndarray
+        2D array of values on irregular grid.
+    lon_irregular, lat_irregular : np.ndarray
+        2D arrays of irregular grid coordinates (degrees).
+    lon_regular, lat_regular : np.ndarray
+        2D arrays of regular grid coordinates (degrees).
+    method : str, default="bilinear"
+        Interpolation method: "bilinear" or "nearest".
+    fill_value : float, default=np.nan
+        Value for output points that fall outside input grid.
+    use_spatial_index : bool, default=True
+        If True, build a spatial index (KD-tree) for faster cell finding.
+        Recommended for large grids (>100×100). Adds ~0.1s overhead.
+
+    Returns
+    -------
+    data_regular : np.ndarray
+        2D array of interpolated values on regular grid.
+
+    Notes
+    -----
+    Algorithm (follows MATLAB Chip_regrid2.m):
+    1. For each point P in regular grid:
+       a. Search for containing quadrilateral in irregular grid
+       b. Perform bilinear interpolation using 4 corner values
+    2. Optimization: Use spatial locality (start search near last found cell)
+    3. Points outside irregular grid are filled with fill_value
+
+    Performance: O(n²) worst case, O(n²/k) typical with spatial locality.
+
+    Optimizations applied:
+    - Minimize array allocations in inner loop
+    - Extract corner data once per cell
+    - Use scalar operations where possible
+    - Optional spatial index for O(log n) nearest neighbor queries
+    """
+    nrows_out, ncols_out = lon_regular.shape
+    data_regular = np.full((nrows_out, ncols_out), fill_value)
+
+    # Build spatial index if enabled (speeds up cell finding for large grids)
+    kdtree = None
+    cell_centers = None
+    if use_spatial_index and lon_irregular.shape[0] > 50:
+        try:
+            from scipy.spatial import cKDTree
+
+            # Compute cell centers for spatial index
+            nrows_in, ncols_in = lon_irregular.shape
+            cell_centers_list = []
+            cell_indices_list = []
+
+            for i in range(nrows_in - 1):
+                for j in range(ncols_in - 1):
+                    # Cell center (approximate)
+                    center_lon = 0.25 * (
+                        lon_irregular[i, j]
+                        + lon_irregular[i, j + 1]
+                        + lon_irregular[i + 1, j]
+                        + lon_irregular[i + 1, j + 1]
+                    )
+                    center_lat = 0.25 * (
+                        lat_irregular[i, j]
+                        + lat_irregular[i, j + 1]
+                        + lat_irregular[i + 1, j]
+                        + lat_irregular[i + 1, j + 1]
+                    )
+                    cell_centers_list.append([center_lon, center_lat])
+                    cell_indices_list.append((i, j))
+
+            cell_centers = np.array(cell_centers_list)
+            cell_indices_map = cell_indices_list
+            kdtree = cKDTree(cell_centers)
+            logger.debug(f"Built spatial index with {len(cell_indices_map)} cells")
+
+        except ImportError:
+            logger.debug("scipy.spatial.cKDTree not available, using sequential search")
+            kdtree = None
+
+    # Track last found cell for optimization (spatial locality)
+    last_cell = None
+    first_cell_of_row = None
+
+    logger.info(f"Regridding {nrows_out}×{ncols_out} points using {method} interpolation...")
+
+    # Iterate through regular grid points
+    for ii in range(nrows_out):
+        if ii % 50 == 0:
+            logger.debug(f"  Processing row {ii + 1}/{nrows_out}")
+
+        # Reset search hint at start of each row (follow MATLAB pattern)
+        if first_cell_of_row is not None:
+            last_cell = first_cell_of_row
+
+        for jj in range(ncols_out):
+            point_lon = lon_regular[ii, jj]
+            point_lat = lat_regular[ii, jj]
+            point = np.array([point_lon, point_lat])
+
+            cell = None
+
+            # Strategy:
+            # 1. If we have a hint from previous point, use windowed search
+            # 2. If windowed search fails or no hint, use spatial index
+            # 3. If no spatial index, do full search (slow, but correct)
+
+            if last_cell is not None:
+                # Try windowed search around last cell
+                cell = find_containing_cell(point, lon_irregular, lat_irregular, last_cell)
+
+            # If windowed search failed or no hint, use spatial index
+            if cell is None and kdtree is not None:
+                # Query k nearest neighbors to find containing cell
+                distances, indices = kdtree.query(point, k=min(9, len(cell_centers)))
+
+                for idx in indices:
+                    candidate_i, candidate_j = cell_indices_map[idx]
+                    # Direct check if point is in this candidate cell (fast)
+                    if _check_point_in_cell(
+                        point_lon, point_lat, lon_irregular, lat_irregular, candidate_i, candidate_j
+                    ):
+                        cell = (candidate_i, candidate_j)
+                        break
+
+            # Last resort: full search (only if no spatial index available)
+            if cell is None and kdtree is None:
+                cell = find_containing_cell(point, lon_irregular, lat_irregular, None)
+
+            if cell is None:
+                # Point outside irregular grid, leave as fill_value
+                continue
+
+            i, j = cell
+
+            # Get corner coordinates and values (extract once)
+            # Clockwise from top-left: TL, TR, BR, BL
+            lon_tl, lat_tl = lon_irregular[i, j], lat_irregular[i, j]
+            lon_tr, lat_tr = lon_irregular[i, j + 1], lat_irregular[i, j + 1]
+            lon_br, lat_br = lon_irregular[i + 1, j + 1], lat_irregular[i + 1, j + 1]
+            lon_bl, lat_bl = lon_irregular[i + 1, j], lat_irregular[i + 1, j]
+
+            val_tl = data_irregular[i, j]
+            val_tr = data_irregular[i, j + 1]
+            val_br = data_irregular[i + 1, j + 1]
+            val_bl = data_irregular[i + 1, j]
+
+            # Interpolate
+            if method == "bilinear":
+                # Inline bilinear interpolation (avoid function call overhead)
+                # Build interpolation matrix (4x4) and solve
+                M = np.array(
+                    [
+                        [1.0, 1.0, 1.0, 1.0],
+                        [lon_tl, lon_tr, lon_br, lon_bl],
+                        [lat_tl, lat_tr, lat_br, lat_bl],
+                        [lon_tl * lat_tl, lon_tr * lat_tr, lon_br * lat_br, lon_bl * lat_bl],
+                    ]
+                )
+
+                E = np.array([1.0, point_lon, point_lat, point_lon * point_lat])
+
+                try:
+                    weights = np.linalg.solve(M, E)
+                    data_regular[ii, jj] = (
+                        weights[0] * val_tl + weights[1] * val_tr + weights[2] * val_br + weights[3] * val_bl
+                    )
+                except np.linalg.LinAlgError:
+                    # Singular matrix - use simple average
+                    data_regular[ii, jj] = 0.25 * (val_tl + val_tr + val_br + val_bl)
+
+            elif method == "nearest":
+                # Use nearest corner (avoid extra array allocations)
+                dist_tl = (lon_tl - point_lon) ** 2 + (lat_tl - point_lat) ** 2
+                dist_tr = (lon_tr - point_lon) ** 2 + (lat_tr - point_lat) ** 2
+                dist_br = (lon_br - point_lon) ** 2 + (lat_br - point_lat) ** 2
+                dist_bl = (lon_bl - point_lon) ** 2 + (lat_bl - point_lat) ** 2
+
+                min_dist = min(dist_tl, dist_tr, dist_br, dist_bl)
+                if min_dist == dist_tl:
+                    data_regular[ii, jj] = val_tl
+                elif min_dist == dist_tr:
+                    data_regular[ii, jj] = val_tr
+                elif min_dist == dist_br:
+                    data_regular[ii, jj] = val_br
+                else:
+                    data_regular[ii, jj] = val_bl
+
+            # Update search hint
+            last_cell = cell
+            if jj == 0:
+                first_cell_of_row = cell
+
+    logger.info("Regridding complete")
+
+    return data_regular
+
+
+def regrid_gcp_chip(
+    band_data: np.ndarray,
+    ecef_coords: tuple[np.ndarray, np.ndarray, np.ndarray],
+    config: RegridConfig,
+    output_file: str | None = None,
+    output_metadata: dict[str, str] | None = None,
+) -> ImageGrid:
+    """
+    High-level function: Regrid GCP chip from ECEF to regular lat/lon grid.
+
+    This is the main entry point for GCP chip regridding. It handles the complete
+    workflow from ECEF coordinates to a regular geodetic grid.
+
+    Parameters
+    ----------
+    band_data : np.ndarray
+        2D array of radiometric values.
+    ecef_coords : tuple[np.ndarray, np.ndarray, np.ndarray]
+        (X, Y, Z) ECEF coordinate arrays (meters), each shape (nrows, ncols).
+    config : RegridConfig
+        Regridding configuration.
+    output_file : str, optional
+        If provided, save the regridded chip to this NetCDF file path.
+        File will be created with CF-compliant metadata.
+    output_metadata : dict[str, str], optional
+        Additional metadata to include in the NetCDF file (only used if output_file
+        is specified). Common keys: 'source_file', 'mission', 'sensor', 'band'.
+
+    Returns
+    -------
+    regridded_chip : ImageGrid
+        Regridded data on regular lat/lon grid.
+
+    Workflow
+    --------
+    1. Convert ECEF → geodetic (lon, lat, h) using curryer.compute.spatial
+    2. Compute regular grid bounds (conservative or full extent)
+    3. Create regular output grid (from resolution or size)
+    4. Regrid data using bilinear interpolation
+    5. Return ImageGrid with (data, lat, lon, h)
+    6. Optionally save to NetCDF file
+
+    Examples
+    --------
+    Basic usage (return in-memory):
+
+    >>> from curryer.correction.image_io import load_gcp_chip_from_hdf
+    >>> from curryer.correction.regrid import regrid_gcp_chip, RegridConfig
+    >>> band, x, y, z = load_gcp_chip_from_hdf("chip.hdf")
+    >>> config = RegridConfig(output_resolution_deg=(0.001, 0.001))
+    >>> regridded = regrid_gcp_chip(band, (x, y, z), config)
+
+    With NetCDF output:
+
+    >>> regridded = regrid_gcp_chip(
+    ...     band, (x, y, z), config,
+    ...     output_file="regridded_chip.nc",
+    ...     output_metadata={
+    ...         'source_file': 'LT08CHP.20140803.p002r071.c01.v001.hdf',
+    ...         'mission': 'CLARREO Pathfinder',
+    ...         'band': 'red',
+    ...     }
+    ... )
+    """
+    ecef_x, ecef_y, ecef_z = ecef_coords
+
+    # Validate input shapes
+    if not (band_data.shape == ecef_x.shape == ecef_y.shape == ecef_z.shape):
+        raise ValueError(
+            f"Shape mismatch: band={band_data.shape}, x={ecef_x.shape}, y={ecef_y.shape}, z={ecef_z.shape}"
+        )
+
+    logger.info(f"Regridding GCP chip: input shape {band_data.shape}")
+
+    # Step 1: Convert ECEF → geodetic
+    logger.debug("Converting ECEF → geodetic coordinates...")
+    nrows, ncols = band_data.shape
+
+    # Flatten for vectorized conversion
+    ecef_flat = np.stack([ecef_x.ravel(), ecef_y.ravel(), ecef_z.ravel()], axis=1)
+
+    # Convert using Curryer's spatial module (vectorized, uses WGS84)
+    lla_flat = ecef_to_geodetic(ecef_flat, meters=True, degrees=True)
+
+    # Reshape back to 2D grids
+    lon_irregular = lla_flat[:, 0].reshape(nrows, ncols)
+    lat_irregular = lla_flat[:, 1].reshape(nrows, ncols)
+
+    logger.debug(
+        f"Geodetic range: lon=[{lon_irregular.min():.4f}, {lon_irregular.max():.4f}], "
+        f"lat=[{lat_irregular.min():.4f}, {lat_irregular.max():.4f}]"
+    )
+
+    # Step 2: Determine output grid bounds
+    if config.output_bounds is not None:
+        bounds = config.output_bounds
+        logger.debug(f"Using explicit bounds: {bounds}")
+    else:
+        bounds = compute_regular_grid_bounds(lon_irregular, lat_irregular, config.conservative_bounds)
+        logger.debug(f"Computed bounds: {bounds}")
+
+    # Step 3: Create regular grid
+    if config.output_resolution_deg is not None:
+        lon_regular, lat_regular = create_regular_grid(bounds, resolution=config.output_resolution_deg)
+    elif config.output_grid_size is not None:
+        lon_regular, lat_regular = create_regular_grid(bounds, grid_size=config.output_grid_size)
+    else:
+        # Auto mode: use input size
+        logger.debug("Auto mode: using input grid size")
+        lon_regular, lat_regular = create_regular_grid(bounds, grid_size=band_data.shape)
+
+    # Step 4: Regrid data
+    data_regular = regrid_irregular_to_regular(
+        band_data,
+        lon_irregular,
+        lat_irregular,
+        lon_regular,
+        lat_regular,
+        method=config.interpolation_method,
+        fill_value=config.fill_value,
+    )
+
+    # Step 5: Create ImageGrid
+    # Note: h is not regridded (would need separate interpolation), set to None
+    regridded_chip = ImageGrid(
+        data=data_regular,
+        lat=lat_regular,
+        lon=lon_regular,
+        h=None,  # Height not interpolated
+    )
+
+    logger.info(f"Regridding complete: output shape {data_regular.shape}")
+
+    # Step 6: Optionally save to NetCDF
+    if output_file is not None:
+        from .image_io import save_image_grid_to_netcdf
+
+        save_image_grid_to_netcdf(output_file, regridded_chip, metadata=output_metadata)
+
+    return regridded_chip

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -3,8 +3,10 @@
    :caption: Contents:
 
    users.md
+   gcp_regridding.md
    developers.md
    acknowledgements.md
    repo_data.md
    changelog.md
    autoapi/index.rst
+

--- a/docs/source/gcp_regridding.md
+++ b/docs/source/gcp_regridding.md
@@ -1,0 +1,242 @@
+# GCP Chip Regridding
+
+Ground Control Point (GCP) reference imagery from missions such as CLARREO
+Pathfinder arrives as raw HDF files (Landsat format) in which each pixel's
+position is stored as Earth-Centered, Earth-Fixed (ECEF) X/Y/Z coordinates on
+an irregular geodetic grid. Before these chips can be matched against L1A
+science images, they must be resampled onto a regular latitude/longitude grid
+that matches the spatial resolution of the mission's detector.
+
+The `curryer.correction` package provides a complete pipeline for this:
+
+```
+HDF chip  →  ECEF → WGS84 geodetic  →  bilinear regrid  →  regular NetCDF grid
+```
+
+---
+
+## Quick start — single file (Python)
+
+```python
+from pathlib import Path
+from curryer.correction.data_structures import RegridConfig
+from curryer.correction.image_io import load_gcp_chip_from_hdf
+from curryer.correction.regrid import regrid_gcp_chip
+
+# 1. Load raw chip (returns band data + ECEF X/Y/Z arrays)
+band, ecef_x, ecef_y, ecef_z = load_gcp_chip_from_hdf(
+    Path("LT08CHP.20140803.p002r071.c01.v001.hdf")
+)
+
+# 2. Configure regridding (~100 m resolution for CLARREO)
+config = RegridConfig(output_resolution_deg=(0.0009, 0.0009))
+
+# 3. Regrid and save in one call
+regridded = regrid_gcp_chip(
+    band,
+    (ecef_x, ecef_y, ecef_z),
+    config,
+    output_file="regridded_chip.nc",
+    output_metadata={
+        "source_file": "LT08CHP.20140803.p002r071.c01.v001.hdf",
+        "mission": "CLARREO Pathfinder",
+        "sensor": "Landsat-8",
+        "band": "red",
+    },
+)
+
+# 4. regridded is an ImageGrid — ready for image matching
+print(regridded.data.shape)   # e.g. (421, 433)
+print(regridded.lat[0, 0])    # top-left latitude
+```
+
+---
+
+## Batch processing — command-line script
+
+For a directory of 100 Landsat chips use the provided script directly:
+
+```bash
+# Regrid all *.hdf files in /data/landsat_gcps/ and write NetCDF to /data/regridded/
+python scripts/regrid_gcp_chips.py /data/landsat_gcps/ /data/regridded/
+```
+
+Output:
+
+```
+Processing 100 file(s) → /data/regridded/
+
+[ 1/100] START LT08CHP.20140101.p002r071.c01.v001.hdf
+         ✓ LT08CHP.20140101.p002r071.c01.v001_regridded.nc  (1823 KB, 4.2s)
+[ 2/100] START LT08CHP.20140116.p002r071.c01.v001.hdf
+         ✓ LT08CHP.20140116.p002r071.c01.v001_regridded.nc  (1791 KB, 4.0s)
+...
+────────────────────────────────────────────────────────────
+Finished: all 100 file(s) processed successfully.
+```
+
+### Common options
+
+| Flag                       | Default              | Description                                       |
+| -------------------------- | -------------------- | ------------------------------------------------- |
+| `--resolution DLAT DLON`   | `0.0009 0.0009`      | Output resolution in degrees (~100 m)             |
+| `--pattern GLOB`           | `*.hdf`              | Filename pattern when source is a directory       |
+| `--mission NAME`           | `CLARREO Pathfinder` | Written to NetCDF `mission` attribute             |
+| `--band DATASET`           | `Band_1`             | HDF dataset name for the radiometric channel      |
+| `--skip-existing`          | off                  | Skip files whose output `.nc` already exists      |
+| `--dry-run`                | off                  | Print what would be done, write nothing           |
+| `--no-conservative-bounds` | off                  | Use full ECEF extent (may include edge artefacts) |
+| `-v` / `--verbose`         | off                  | Show per-row progress and DEBUG log output        |
+
+### Resume an interrupted run
+
+```bash
+# Already processed 60/100 — pick up from where it stopped
+python scripts/regrid_gcp_chips.py /data/landsat_gcps/ /data/regridded/ --skip-existing
+```
+
+### Preview before committing
+
+```bash
+python scripts/regrid_gcp_chips.py /data/landsat_gcps/ /data/regridded/ --dry-run
+```
+
+### Non-standard band or file pattern
+
+```bash
+# Band_4 (near-IR), only files matching a date range
+python scripts/regrid_gcp_chips.py /data/ /out/ \
+    --pattern "LT08CHP.2016*.hdf" \
+    --band Band_4 \
+    --resolution 0.001 0.001
+```
+
+---
+
+## Batch processing — Python API
+
+Use this when you need custom logic (filtering, parallel execution, etc.):
+
+```python
+from pathlib import Path
+from curryer.correction.data_structures import RegridConfig
+from curryer.correction.image_io import load_gcp_chip_from_hdf
+from curryer.correction.regrid import regrid_gcp_chip
+
+input_dir  = Path("/data/landsat_gcps")
+output_dir = Path("/data/regridded")
+output_dir.mkdir(parents=True, exist_ok=True)
+
+config = RegridConfig(output_resolution_deg=(0.0009, 0.0009))
+
+hdf_files = sorted(input_dir.glob("LT08CHP.*.hdf"))
+print(f"Found {len(hdf_files)} chips")
+
+errors = {}
+for hdf_file in hdf_files:
+    nc_file = output_dir / f"{hdf_file.stem}_regridded.nc"
+
+    try:
+        band, ecef_x, ecef_y, ecef_z = load_gcp_chip_from_hdf(hdf_file)
+        regrid_gcp_chip(
+            band,
+            (ecef_x, ecef_y, ecef_z),
+            config,
+            output_file=str(nc_file),
+            output_metadata={"source_file": hdf_file.name, "mission": "CLARREO Pathfinder"},
+        )
+        print(f"  ✓ {hdf_file.name}")
+    except Exception as exc:
+        errors[hdf_file.name] = str(exc)
+        print(f"  ✗ {hdf_file.name}: {exc}")
+
+if errors:
+    print(f"\n{len(errors)} file(s) failed:", *errors, sep="\n  ")
+```
+
+### Loading the regridded output
+
+The output NetCDF files are `ImageGrid`-compatible and plug directly into the
+correction pipeline:
+
+```python
+from curryer.correction.image_io import load_gcp_chip_from_netcdf
+
+gcp = load_gcp_chip_from_netcdf(Path("regridded_chip.nc"))
+# gcp.data  — 2-D radiometric values
+# gcp.lat   — 2-D latitude  (regular grid, decreasing from top to bottom)
+# gcp.lon   — 2-D longitude (regular grid, increasing left to right)
+# gcp.h     — 2-D height above WGS84 ellipsoid (metres), or None
+```
+
+---
+
+## Configuration reference
+
+```python
+from curryer.correction.data_structures import RegridConfig
+
+# Resolution-based (most common)
+config = RegridConfig(output_resolution_deg=(0.0009, 0.0009))
+
+# Fixed output size
+config = RegridConfig(output_grid_size=(500, 500))
+
+# Explicit geographic extent + resolution
+config = RegridConfig(
+    output_bounds=(-116.5, -115.5, 38.0, 39.0),   # (minlon, maxlon, minlat, maxlat)
+    output_resolution_deg=(0.001, 0.001),
+)
+
+# Disable conservative clipping (use full ECEF extent)
+config = RegridConfig(
+    output_resolution_deg=(0.0009, 0.0009),
+    conservative_bounds=False,
+)
+```
+
+| Parameter               | Type                               | Description                                                               |
+| ----------------------- | ---------------------------------- | ------------------------------------------------------------------------- |
+| `output_resolution_deg` | `(dlat, dlon)`                     | Grid spacing in degrees. Mutually exclusive with `output_grid_size`.      |
+| `output_grid_size`      | `(nrows, ncols)`                   | Fixed output dimensions. Mutually exclusive with `output_resolution_deg`. |
+| `output_bounds`         | `(minlon, maxlon, minlat, maxlat)` | Explicit geographic extent. Requires `output_resolution_deg`.             |
+| `conservative_bounds`   | `bool` (default `True`)            | Shrink bounds to grid interior to avoid edge extrapolation.               |
+| `interpolation_method`  | `"bilinear"` \| `"nearest"`        | Interpolation algorithm (default `"bilinear"`).                           |
+| `fill_value`            | `float` (default `NaN`)            | Value assigned to output points outside the input footprint.              |
+
+---
+
+## Output NetCDF structure
+
+```
+dimensions:  y (rows), x (cols)
+variables:
+  band_data(y, x)   — radiometric values      [digital_number]
+  lat(y, x)         — latitude                [degrees_north]
+  lon(y, x)         — longitude               [degrees_east]
+  h(y, x)           — height above WGS84      [metres]  (present when height is available)
+global attributes:
+  title, Conventions (CF-1.8), source_file, mission, band, processing_software, …
+```
+
+> **Coordinate convention:** row 0 is northernmost (latitude decreases down),
+> column 0 is westernmost (longitude increases right) — consistent with the
+> MATLAB `Chip_regrid2.m` output format.
+
+---
+
+## Notes
+
+- **Ellipsoid:** ECEF → geodetic conversion always uses **WGS84**
+  (`curryer.compute.spatial.ecef_to_geodetic`). This is correct for
+  Landsat-8/9 GCP chips.
+
+- **HDF format:** `load_gcp_chip_from_hdf` tries HDF4 (`pyhdf`) first, then
+  falls back to HDF5 (`h5py`). Both are handled transparently.
+
+- **Memory:** a 1400 × 1400 Landsat chip uses ~30 MB RAM; 100 chips processed
+  sequentially stay well within a 4 GB budget. If memory is tight, process
+  files one at a time (the CLI script already does this).
+
+- **Performance:** each chip typically takes 3–6 seconds on a single CPU core.
+  100 chips ≈ 5–10 minutes.

--- a/scripts/example_regrid_to_netcdf.py
+++ b/scripts/example_regrid_to_netcdf.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+"""
+Example: Regrid GCP chip and save to NetCDF
+
+This script demonstrates the new NetCDF output functionality for GCP regridding.
+It can be used as a template for batch processing GCP chips.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+from curryer.correction.image_io import load_gcp_chip_from_hdf
+from curryer.correction.regrid import RegridConfig, regrid_gcp_chip
+
+
+def regrid_and_save_gcp_chip(
+    input_file: Path,
+    output_file: Path,
+    mission: str = "CLARREO Pathfinder",
+    resolution_deg: tuple[float, float] = (0.0009, 0.0009),
+) -> None:
+    """
+    Load, regrid, and save a GCP chip to NetCDF.
+
+    Parameters
+    ----------
+    input_file : Path
+        Input HDF file containing raw GCP chip.
+    output_file : Path
+        Output NetCDF file path.
+    mission : str
+        Mission name for metadata.
+    resolution_deg : tuple[float, float]
+        Output resolution (dlat, dlon) in degrees.
+    """
+    print(f"Processing: {input_file.name}")
+
+    # Load raw GCP chip
+    print("  Loading raw chip...")
+    band, x, y, z = load_gcp_chip_from_hdf(input_file)
+    print(f"    Input shape: {band.shape}")
+
+    # Configure regridding
+    config = RegridConfig(
+        output_resolution_deg=resolution_deg,
+        conservative_bounds=True,
+        interpolation_method="bilinear",
+    )
+
+    # Prepare metadata
+    metadata = {
+        "source_file": input_file.name,
+        "mission": mission,
+        "sensor": "Landsat-8",
+        "band": "red (Band 1)",
+        "resolution_deg": f"{resolution_deg[0]}°, {resolution_deg[1]}°",
+        "processing_software": "curryer",
+    }
+
+    # Regrid and save
+    print("  Regridding...")
+    regridded = regrid_gcp_chip(
+        band,
+        (x, y, z),
+        config,
+        output_file=str(output_file),
+        output_metadata=metadata,
+    )
+
+    print(f"    Output shape: {regridded.data.shape}")
+    print(f"    Valid pixels: {(~np.isnan(regridded.data)).sum()}/{regridded.data.size}")
+    print(f"  Saved to: {output_file}")
+    print(f"    File size: {output_file.stat().st_size / (1024**2):.2f} MB")
+
+
+def main():
+    """Example usage: Process a single GCP chip."""
+    # Example file paths
+    input_file = Path("tests/data/clarreo/landsat_gcp/LT08CHP.20140803.p002r071.c01.v001.hdf")
+    output_dir = Path("output/regridded_gcps")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_file = output_dir / "LT08CHP.20140803.p002r071.c01.v001_regridded.nc"
+
+    if not input_file.exists():
+        print(f"Error: Input file not found: {input_file}")
+        print("\nUpdate the script with your GCP chip path.")
+        return
+
+    # Process with CLARREO-specific resolution (~100m)
+    regrid_and_save_gcp_chip(
+        input_file,
+        output_file,
+        mission="CLARREO Pathfinder",
+        resolution_deg=(0.0009, 0.0009),
+    )
+
+    print("\n✓ Processing complete!")
+
+
+def batch_process_example():
+    """Example: Batch process multiple GCP chips."""
+    input_dir = Path("tests/data/clarreo/landsat_gcp")
+    output_dir = Path("output/regridded_gcps")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Find all HDF files
+    hdf_files = list(input_dir.glob("LT08CHP.*.hdf"))
+
+    if not hdf_files:
+        print(f"No HDF files found in {input_dir}")
+        return
+
+    print(f"Found {len(hdf_files)} GCP chips to process\n")
+
+    for input_file in hdf_files:
+        output_file = output_dir / f"{input_file.stem}_regridded.nc"
+
+        try:
+            regrid_and_save_gcp_chip(input_file, output_file)
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            continue
+
+        print()
+
+    print(f"✓ Batch processing complete! Processed {len(hdf_files)} chips.")
+
+
+if __name__ == "__main__":
+    # Run single file example
+    main()
+
+    # Uncomment to run batch processing
+    # batch_process_example()

--- a/scripts/regrid_gcp_chips.py
+++ b/scripts/regrid_gcp_chips.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python
+"""Batch-regrid Landsat (or other HDF) GCP chips to regular lat/lon NetCDF files.
+
+Usage
+-----
+Single file::
+
+    python scripts/regrid_gcp_chips.py input.hdf output_dir/
+
+Directory of HDF files::
+
+    python scripts/regrid_gcp_chips.py /data/landsat_gcps/ /data/regridded/
+
+Custom resolution and glob pattern::
+
+    python scripts/regrid_gcp_chips.py /data/ /out/ \\
+        --pattern "LT08CHP.*.hdf" \\
+        --resolution 0.001 0.001
+
+Resume an interrupted run (skip already-converted files)::
+
+    python scripts/regrid_gcp_chips.py /data/ /out/ --skip-existing
+
+Preview what would be processed without writing any files::
+
+    python scripts/regrid_gcp_chips.py /data/ /out/ --dry-run
+
+See all options::
+
+    python scripts/regrid_gcp_chips.py --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Core per-file processing
+# ---------------------------------------------------------------------------
+
+
+def regrid_one(
+    input_file: Path,
+    output_file: Path,
+    resolution_deg: tuple[float, float],
+    conservative_bounds: bool,
+    mission: str,
+    band_name: str,
+) -> None:
+    """Load one HDF chip, regrid it, and write the result to a NetCDF file.
+
+    Parameters
+    ----------
+    input_file : Path
+        Source HDF4 or HDF5 chip file.
+    output_file : Path
+        Destination NetCDF file.  Parent directory must already exist.
+    resolution_deg : tuple[float, float]
+        Output grid resolution as ``(dlat, dlon)`` in degrees.
+    conservative_bounds : bool
+        Shrink output bounds to the interior of the input grid when ``True``
+        (avoids edge extrapolation artefacts).
+    mission : str
+        Mission label written to the ``mission`` global attribute.
+    band_name : str
+        HDF dataset name for the radiometric band (default ``"Band_1"``).
+    """
+    from curryer.correction.data_structures import RegridConfig
+    from curryer.correction.image_io import load_gcp_chip_from_hdf
+    from curryer.correction.regrid import regrid_gcp_chip
+
+    band, ecef_x, ecef_y, ecef_z = load_gcp_chip_from_hdf(input_file, band_name=band_name)
+
+    config = RegridConfig(
+        output_resolution_deg=resolution_deg,
+        conservative_bounds=conservative_bounds,
+        interpolation_method="bilinear",
+    )
+
+    metadata = {
+        "source_file": input_file.name,
+        "mission": mission,
+        "band": band_name,
+        "resolution_deg": f"{resolution_deg[0]}, {resolution_deg[1]}",
+        "processing_software": "curryer",
+    }
+
+    regrid_gcp_chip(
+        band,
+        (ecef_x, ecef_y, ecef_z),
+        config,
+        output_file=str(output_file),
+        output_metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch driver
+# ---------------------------------------------------------------------------
+
+
+def collect_inputs(source: Path, pattern: str) -> list[Path]:
+    """Return a sorted list of HDF files to process.
+
+    Parameters
+    ----------
+    source : Path
+        Either a single HDF file or a directory to search.
+    pattern : str
+        Glob pattern applied when *source* is a directory.
+    """
+    if source.is_file():
+        return [source]
+    files = sorted(source.glob(pattern))
+    if not files:
+        logger.warning("No files matched pattern %r in %s", pattern, source)
+    return files
+
+
+def output_path_for(input_file: Path, output_dir: Path) -> Path:
+    """Derive the output NetCDF path from an input HDF filename."""
+    return output_dir / f"{input_file.stem}_regridded.nc"
+
+
+def run_batch(
+    input_files: list[Path],
+    output_dir: Path,
+    resolution_deg: tuple[float, float],
+    conservative_bounds: bool,
+    skip_existing: bool,
+    dry_run: bool,
+    mission: str,
+    band_name: str,
+) -> int:
+    """Process *input_files* and return the number of failures."""
+    total = len(input_files)
+    failures: list[tuple[Path, str]] = []
+
+    print(f"{'DRY RUN — ' if dry_run else ''}Processing {total} file(s) → {output_dir}\n")
+
+    for idx, input_file in enumerate(input_files, start=1):
+        output_file = output_path_for(input_file, output_dir)
+        prefix = f"[{idx:>{len(str(total))}}/{total}]"
+
+        if skip_existing and output_file.exists():
+            print(f"{prefix} SKIP  {input_file.name}  (already exists)")
+            continue
+
+        print(f"{prefix} START {input_file.name}")
+
+        if dry_run:
+            print(f"        → {output_file}")
+            continue
+
+        t0 = time.monotonic()
+        try:
+            regrid_one(input_file, output_file, resolution_deg, conservative_bounds, mission, band_name)
+            elapsed = time.monotonic() - t0
+            size_kb = output_file.stat().st_size / 1024
+            print(f"        ✓ {output_file.name}  ({size_kb:.0f} KB, {elapsed:.1f}s)")
+        except Exception as exc:  # noqa: BLE001
+            elapsed = time.monotonic() - t0
+            msg = str(exc)
+            failures.append((input_file, msg))
+            print(f"        ✗ FAILED ({elapsed:.1f}s): {msg}")
+            logger.debug("Traceback for %s:", input_file.name, exc_info=True)
+
+    # Summary
+    print(f"\n{'─' * 60}")
+    if dry_run:
+        print(f"Dry run complete — {total} file(s) would be processed.")
+    elif failures:
+        print(f"Finished: {total - len(failures)}/{total} succeeded, {len(failures)} failed.")
+        print("\nFailed files:")
+        for path, reason in failures:
+            print(f"  {path.name}: {reason}")
+    else:
+        print(f"Finished: all {total} file(s) processed successfully.")
+
+    return len(failures)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="regrid_gcp_chips",
+        description="Batch-regrid HDF GCP chips to regular lat/lon NetCDF files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "source",
+        type=Path,
+        help="Single HDF file or directory containing HDF files.",
+    )
+    parser.add_argument(
+        "output_dir",
+        type=Path,
+        help="Directory where regridded NetCDF files are written (created if needed).",
+    )
+    parser.add_argument(
+        "--pattern",
+        default="*.hdf",
+        metavar="GLOB",
+        help="Glob pattern for HDF files when source is a directory (default: '*.hdf').",
+    )
+    parser.add_argument(
+        "--resolution",
+        nargs=2,
+        type=float,
+        default=[0.0009, 0.0009],
+        metavar=("DLAT", "DLON"),
+        help="Output grid resolution in degrees (default: 0.0009 0.0009 ≈ 100 m).",
+    )
+    parser.add_argument(
+        "--no-conservative-bounds",
+        dest="conservative_bounds",
+        action="store_false",
+        default=True,
+        help="Use full ECEF extent instead of shrinking bounds to avoid edge extrapolation.",
+    )
+    parser.add_argument(
+        "--mission",
+        default="CLARREO Pathfinder",
+        help="Mission name written to NetCDF metadata (default: 'CLARREO Pathfinder').",
+    )
+    parser.add_argument(
+        "--band",
+        default="Band_1",
+        metavar="DATASET",
+        help="HDF dataset name for the radiometric band (default: 'Band_1').",
+    )
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip files whose output NetCDF already exists (useful for resuming).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be done without writing any files.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG logging (shows per-row regridding progress).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    source: Path = args.source
+    output_dir: Path = args.output_dir
+    resolution_deg = (args.resolution[0], args.resolution[1])
+
+    if not source.exists():
+        parser.error(f"source does not exist: {source}")
+
+    if not args.dry_run:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    input_files = collect_inputs(source, args.pattern)
+    if not input_files:
+        print(f"No files found. Check --pattern (currently {args.pattern!r}).")
+        sys.exit(1)
+
+    n_failures = run_batch(
+        input_files=input_files,
+        output_dir=output_dir,
+        resolution_deg=resolution_deg,
+        conservative_bounds=args.conservative_bounds,
+        skip_existing=args.skip_existing,
+        dry_run=args.dry_run,
+        mission=args.mission,
+        band_name=args.band,
+    )
+
+    sys.exit(1 if n_failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_correction/test_image_io.py
+++ b/tests/test_correction/test_image_io.py
@@ -1,0 +1,163 @@
+"""Unit tests for image_io module.
+
+Tests for MATLAB, HDF, and NetCDF I/O functions.
+"""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from curryer.correction.data_structures import ImageGrid
+from curryer.correction.image_io import (
+    load_gcp_chip_from_hdf,
+    load_gcp_chip_from_netcdf,
+    load_image_grid_from_mat,
+    save_image_grid,
+)
+
+
+class TestImageGridSaveLoad:
+    """Test save/load round-trips for ImageGrid."""
+
+    def test_netcdf_round_trip(self):
+        """Test save and load ImageGrid from NetCDF."""
+        # Create test data
+        data = np.random.rand(50, 50)
+        lat = np.linspace(38.0, 39.0, 50)
+        lon = np.linspace(-116.0, -115.0, 50)
+        lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+
+        original_grid = ImageGrid(data=data, lat=lat_grid, lon=lon_grid)
+
+        # Save to temp file
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid(tmp_path, original_grid, format="netcdf")
+
+            # Load back
+            loaded_grid = load_gcp_chip_from_netcdf(tmp_path)
+
+            # Verify
+            np.testing.assert_array_almost_equal(loaded_grid.data, original_grid.data)
+            np.testing.assert_array_almost_equal(loaded_grid.lat, original_grid.lat)
+            np.testing.assert_array_almost_equal(loaded_grid.lon, original_grid.lon)
+
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_mat_round_trip(self):
+        """Test save and load ImageGrid from MATLAB .mat file."""
+        # Create test data
+        data = np.random.rand(50, 50)
+        lat = np.linspace(38.0, 39.0, 50)
+        lon = np.linspace(-116.0, -115.0, 50)
+        lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+
+        original_grid = ImageGrid(data=data, lat=lat_grid, lon=lon_grid)
+
+        # Save to temp file
+        with tempfile.NamedTemporaryFile(suffix=".mat", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid(tmp_path, original_grid, format="mat")
+
+            # Load back
+            loaded_grid = load_image_grid_from_mat(tmp_path, key="GCP")
+
+            # Verify
+            np.testing.assert_array_almost_equal(loaded_grid.data, original_grid.data)
+            np.testing.assert_array_almost_equal(loaded_grid.lat, original_grid.lat)
+            np.testing.assert_array_almost_equal(loaded_grid.lon, original_grid.lon)
+
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_save_with_metadata(self):
+        """Test saving ImageGrid with custom metadata."""
+        # Create test data
+        data = np.random.rand(10, 10)
+        lat = np.linspace(38.0, 39.0, 10)
+        lon = np.linspace(-116.0, -115.0, 10)
+        lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+
+        grid = ImageGrid(data=data, lat=lat_grid, lon=lon_grid)
+
+        metadata = {
+            "source": "test_chip.hdf",
+            "mission": "test",
+            "creation_date": "2025-01-22",
+        }
+
+        # Save to temp file
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid(tmp_path, grid, format="netcdf", metadata=metadata)
+
+            # Load and check metadata exists
+            import xarray as xr
+
+            ds = xr.open_dataset(tmp_path)
+            assert "source" in ds.attrs
+            assert ds.attrs["source"] == "test_chip.hdf"
+            ds.close()
+
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_invalid_format(self):
+        """Test that invalid format raises ValueError."""
+        data = np.random.rand(10, 10)
+        lat = np.linspace(38.0, 39.0, 10)
+        lon = np.linspace(-116.0, -115.0, 10)
+        lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+
+        grid = ImageGrid(data=data, lat=lat_grid, lon=lon_grid)
+
+        with tempfile.NamedTemporaryFile(suffix=".xyz") as tmp:
+            tmp_path = Path(tmp.name)
+            with pytest.raises(ValueError, match="Unsupported format"):
+                save_image_grid(tmp_path, grid, format="invalid_format")
+
+
+class TestHDFLoading:
+    """Test HDF file loading (requires test data)."""
+
+    def test_missing_file(self):
+        """Test that missing file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_gcp_chip_from_hdf(Path("nonexistent.hdf"))
+
+    def test_shape_validation(self):
+        """Test that shape mismatches are detected."""
+        # This would require creating a mock HDF file with mismatched shapes
+        # Skipping for now as it requires h5py and proper test fixtures
+        pass
+
+
+class TestNetCDFLoading:
+    """Test NetCDF file loading."""
+
+    def test_missing_file(self):
+        """Test that missing file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_gcp_chip_from_netcdf(Path("nonexistent.nc"))
+
+
+class TestMATLoading:
+    """Test MATLAB file loading."""
+
+    def test_missing_file(self):
+        """Test that missing file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_image_grid_from_mat(Path("nonexistent.mat"))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_correction/test_image_io.py
+++ b/tests/test_correction/test_image_io.py
@@ -9,13 +9,35 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from curryer.correction.data_structures import ImageGrid
+from curryer.correction.data_structures import ImageGrid, NamedImageGrid
 from curryer.correction.image_io import (
     load_gcp_chip_from_hdf,
     load_gcp_chip_from_netcdf,
     load_image_grid_from_mat,
+    load_image_grid_from_netcdf,
     save_image_grid,
+    save_image_grid_to_netcdf,
 )
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_grid(rows: int = 10, cols: int = 10, with_height: bool = False) -> ImageGrid:
+    """Return a small deterministic ImageGrid for use in tests."""
+    rng = np.random.default_rng(0)
+    data = rng.random((rows, cols))
+    lat = np.linspace(38.0, 39.0, rows)
+    lon = np.linspace(-116.0, -115.0, cols)
+    lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+    h = np.zeros((rows, cols)) if with_height else None
+    return ImageGrid(data=data, lat=lat_grid, lon=lon_grid, h=h)
+
+
+# ---------------------------------------------------------------------------
+# save_image_grid / load round-trips
+# ---------------------------------------------------------------------------
 
 
 class TestImageGridSaveLoad:
@@ -23,7 +45,6 @@ class TestImageGridSaveLoad:
 
     def test_netcdf_round_trip(self):
         """Test save and load ImageGrid from NetCDF."""
-        # Create test data
         rng = np.random.default_rng(0)
         data = rng.random((50, 50))
         lat = np.linspace(38.0, 39.0, 50)
@@ -32,27 +53,39 @@ class TestImageGridSaveLoad:
 
         original_grid = ImageGrid(data=data, lat=lat_grid, lon=lon_grid)
 
-        # Save to temp file
         with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
             tmp_path = Path(tmp.name)
 
         try:
             save_image_grid(tmp_path, original_grid, format="netcdf")
 
-            # Load back
             loaded_grid = load_gcp_chip_from_netcdf(tmp_path)
 
-            # Verify
             np.testing.assert_array_almost_equal(loaded_grid.data, original_grid.data)
             np.testing.assert_array_almost_equal(loaded_grid.lat, original_grid.lat)
             np.testing.assert_array_almost_equal(loaded_grid.lon, original_grid.lon)
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
+    def test_netcdf_round_trip_with_height(self):
+        """Height field is preserved through the xarray-based NetCDF round-trip."""
+        original_grid = _make_grid(with_height=True)
+
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid(tmp_path, original_grid, format="netcdf")
+
+            loaded_grid = load_gcp_chip_from_netcdf(tmp_path)
+
+            assert loaded_grid.h is not None
+            np.testing.assert_array_almost_equal(loaded_grid.h, original_grid.h)
         finally:
             tmp_path.unlink(missing_ok=True)
 
     def test_mat_round_trip(self):
         """Test save and load ImageGrid from MATLAB .mat file."""
-        # Create test data
         rng = np.random.default_rng(0)
         data = rng.random((50, 50))
         lat = np.linspace(38.0, 39.0, 50)
@@ -61,27 +94,39 @@ class TestImageGridSaveLoad:
 
         original_grid = ImageGrid(data=data, lat=lat_grid, lon=lon_grid)
 
-        # Save to temp file
         with tempfile.NamedTemporaryFile(suffix=".mat", delete=False) as tmp:
             tmp_path = Path(tmp.name)
 
         try:
             save_image_grid(tmp_path, original_grid, format="mat")
 
-            # Load back
             loaded_grid = load_image_grid_from_mat(tmp_path, key="GCP")
 
-            # Verify
             np.testing.assert_array_almost_equal(loaded_grid.data, original_grid.data)
             np.testing.assert_array_almost_equal(loaded_grid.lat, original_grid.lat)
             np.testing.assert_array_almost_equal(loaded_grid.lon, original_grid.lon)
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
+    def test_mat_round_trip_with_height(self):
+        """Height field is preserved through the MATLAB .mat round-trip."""
+        original_grid = _make_grid(with_height=True)
+
+        with tempfile.NamedTemporaryFile(suffix=".mat", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid(tmp_path, original_grid, format="mat")
+
+            loaded_grid = load_image_grid_from_mat(tmp_path, key="GCP")
+
+            assert loaded_grid.h is not None
+            np.testing.assert_array_almost_equal(loaded_grid.h, original_grid.h)
         finally:
             tmp_path.unlink(missing_ok=True)
 
     def test_save_with_metadata(self):
         """Test saving ImageGrid with custom metadata."""
-        # Create test data
         rng = np.random.default_rng(0)
         data = rng.random((10, 10))
         lat = np.linspace(38.0, 39.0, 10)
@@ -96,21 +141,18 @@ class TestImageGridSaveLoad:
             "creation_date": "2025-01-22",
         }
 
-        # Save to temp file
         with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
             tmp_path = Path(tmp.name)
 
         try:
             save_image_grid(tmp_path, grid, format="netcdf", metadata=metadata)
 
-            # Load and check metadata exists
             import xarray as xr
 
             ds = xr.open_dataset(tmp_path)
             assert "source" in ds.attrs
             assert ds.attrs["source"] == "test_chip.hdf"
             ds.close()
-
         finally:
             tmp_path.unlink(missing_ok=True)
 
@@ -130,19 +172,172 @@ class TestImageGridSaveLoad:
                 save_image_grid(tmp_path, grid, format="invalid_format")
 
 
+# ---------------------------------------------------------------------------
+# CF-1.8 save_image_grid_to_netcdf / load_image_grid_from_netcdf pair
+# ---------------------------------------------------------------------------
+
+
+class TestNetCDF4DirectIO:
+    """Test the lower-level CF-1.8 netCDF4 save/load pair."""
+
+    def test_round_trip_regular_grid(self):
+        """save_image_grid_to_netcdf + load_image_grid_from_netcdf: regular grid."""
+        original_grid = _make_grid(rows=20, cols=25)
+
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid_to_netcdf(tmp_path, original_grid)
+
+            loaded_grid = load_image_grid_from_netcdf(tmp_path)
+
+            assert loaded_grid.data.shape == original_grid.data.shape
+            np.testing.assert_array_almost_equal(loaded_grid.data, original_grid.data)
+            # Coordinates reconstructed from 1-D arrays via meshgrid — values must match
+            np.testing.assert_array_almost_equal(loaded_grid.lat, original_grid.lat)
+            np.testing.assert_array_almost_equal(loaded_grid.lon, original_grid.lon)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_round_trip_with_height(self):
+        """Height is preserved through the netCDF4 round-trip."""
+        original_grid = _make_grid(rows=10, cols=10, with_height=True)
+
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid_to_netcdf(tmp_path, original_grid)
+
+            loaded_grid = load_image_grid_from_netcdf(tmp_path)
+
+            assert loaded_grid.h is not None
+            np.testing.assert_array_almost_equal(loaded_grid.h, original_grid.h)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_round_trip_with_metadata(self):
+        """Metadata attributes are written to the file."""
+        grid = _make_grid()
+        metadata = {"mission": "CLARREO", "band": "red"}
+
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid_to_netcdf(tmp_path, grid, metadata=metadata)
+
+            import xarray as xr
+
+            ds = xr.open_dataset(tmp_path)
+            assert ds.attrs.get("mission") == "CLARREO"
+            assert ds.attrs.get("band") == "red"
+            ds.close()
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_round_trip_irregular_grid(self):
+        """2-D (irregular) coordinate arrays are stored and recovered correctly."""
+        rng = np.random.default_rng(1)
+        nrows, ncols = 8, 10
+        data = rng.random((nrows, ncols))
+        # Distorted grid — coordinates are NOT separable
+        lat_base = np.linspace(38.0, 39.0, nrows)
+        lon_base = np.linspace(-116.0, -115.0, ncols)
+        lon_grid, lat_grid = np.meshgrid(lon_base, lat_base)
+        lat_grid += 0.05 * rng.standard_normal((nrows, ncols))
+        lon_grid += 0.05 * rng.standard_normal((nrows, ncols))
+
+        original_grid = ImageGrid(data=data, lat=lat_grid, lon=lon_grid)
+
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid_to_netcdf(tmp_path, original_grid)
+
+            loaded_grid = load_image_grid_from_netcdf(tmp_path)
+
+            assert loaded_grid.data.shape == original_grid.data.shape
+            np.testing.assert_array_almost_equal(loaded_grid.data, original_grid.data)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_missing_file_raises(self):
+        """load_image_grid_from_netcdf raises FileNotFoundError for absent files."""
+        with pytest.raises(FileNotFoundError):
+            load_image_grid_from_netcdf(Path("does_not_exist.nc"))
+
+
+# ---------------------------------------------------------------------------
+# HDF file loading
+# ---------------------------------------------------------------------------
+
+
 class TestHDFLoading:
-    """Test HDF file loading (requires test data)."""
+    """Test HDF file loading."""
 
     def test_missing_file(self):
         """Test that missing file raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
             load_gcp_chip_from_hdf(Path("nonexistent.hdf"))
 
+    def test_hdf5_round_trip(self):
+        """Load a synthetic HDF5 file via the h5py fallback path."""
+        h5py = pytest.importorskip("h5py")
+
+        rng = np.random.default_rng(0)
+        nrows, ncols = 12, 15
+        band = rng.random((nrows, ncols))
+        ecef_x = rng.random((nrows, ncols)) * 1e6
+        ecef_y = rng.random((nrows, ncols)) * 1e6
+        ecef_z = rng.random((nrows, ncols)) * 1e6
+
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            with h5py.File(tmp_path, "w") as hdf:
+                hdf.create_dataset("Band_1", data=band)
+                hdf.create_dataset("ECR_x_coordinate_array", data=ecef_x)
+                hdf.create_dataset("ECR_y_coordinate_array", data=ecef_y)
+                hdf.create_dataset("ECR_z_coordinate_array", data=ecef_z)
+
+            loaded_band, loaded_x, loaded_y, loaded_z = load_gcp_chip_from_hdf(tmp_path)
+
+            assert loaded_band.shape == (nrows, ncols)
+            np.testing.assert_array_almost_equal(loaded_band, band)
+            np.testing.assert_array_almost_equal(loaded_x, ecef_x)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
     def test_shape_validation(self):
-        """Test that shape mismatches are detected."""
-        # This would require creating a mock HDF file with mismatched shapes
-        # Skipping for now as it requires h5py and proper test fixtures
-        pass
+        """Shape mismatch across HDF5 datasets raises ValueError."""
+        h5py = pytest.importorskip("h5py")
+
+        rng = np.random.default_rng(0)
+
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            with h5py.File(tmp_path, "w") as hdf:
+                hdf.create_dataset("Band_1", data=rng.random((10, 10)))
+                hdf.create_dataset("ECR_x_coordinate_array", data=rng.random((10, 10)))
+                hdf.create_dataset("ECR_y_coordinate_array", data=rng.random((10, 10)))
+                # Deliberately wrong shape for Z
+                hdf.create_dataset("ECR_z_coordinate_array", data=rng.random((5, 10)))
+
+            with pytest.raises(ValueError, match="shape mismatch"):
+                load_gcp_chip_from_hdf(tmp_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# load_gcp_chip_from_netcdf (xarray-based)
+# ---------------------------------------------------------------------------
 
 
 class TestNetCDFLoading:
@@ -153,6 +348,54 @@ class TestNetCDFLoading:
         with pytest.raises(FileNotFoundError):
             load_gcp_chip_from_netcdf(Path("nonexistent.nc"))
 
+    def test_round_trip_with_height(self):
+        """Height variable is loaded when present in file."""
+        original_grid = _make_grid(with_height=True)
+
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid(tmp_path, original_grid, format="netcdf")
+
+            loaded_grid = load_gcp_chip_from_netcdf(tmp_path)
+
+            assert loaded_grid.h is not None
+            np.testing.assert_array_almost_equal(loaded_grid.h, original_grid.h)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_missing_variable_raises(self):
+        """Missing band_data variable in NetCDF raises OSError."""
+        import xarray as xr
+
+        nrows, ncols = 5, 5
+        lat = np.linspace(38.0, 39.0, nrows)
+        lon = np.linspace(-116.0, -115.0, ncols)
+        lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
+
+        # Build a file that is valid NetCDF but lacks "band_data"
+        ds = xr.Dataset(
+            {"lat": (["y", "x"], lat_grid), "lon": (["y", "x"], lon_grid)},
+            coords={"y": np.arange(nrows), "x": np.arange(ncols)},
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            ds.to_netcdf(tmp_path)
+
+            with pytest.raises(OSError, match="band_data"):
+                load_gcp_chip_from_netcdf(tmp_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# load_image_grid_from_mat
+# ---------------------------------------------------------------------------
+
 
 class TestMATLoading:
     """Test MATLAB file loading."""
@@ -162,6 +405,38 @@ class TestMATLoading:
         with pytest.raises(FileNotFoundError):
             load_image_grid_from_mat(Path("nonexistent.mat"))
 
+    def test_missing_key_raises(self):
+        """KeyError is raised when the requested struct key is absent."""
+        from scipy.io import savemat
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+        rng = np.random.default_rng(0)
+        data = rng.random((5, 5))
+
+        with tempfile.NamedTemporaryFile(suffix=".mat", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Save under a different key than will be requested
+            savemat(str(tmp_path), {"other_key": {"data": data}})
+
+            with pytest.raises(KeyError, match="subimage"):
+                load_image_grid_from_mat(tmp_path, key="subimage")
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_as_named_returns_named_image_grid(self):
+        """as_named=True returns a NamedImageGrid with the correct name."""
+        original_grid = _make_grid()
+
+        with tempfile.NamedTemporaryFile(suffix=".mat", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            save_image_grid(tmp_path, original_grid, format="mat")
+
+            loaded = load_image_grid_from_mat(tmp_path, key="GCP", as_named=True)
+
+            assert isinstance(loaded, NamedImageGrid)
+            assert loaded.name is not None
+        finally:
+            tmp_path.unlink(missing_ok=True)

--- a/tests/test_correction/test_image_io.py
+++ b/tests/test_correction/test_image_io.py
@@ -24,7 +24,8 @@ class TestImageGridSaveLoad:
     def test_netcdf_round_trip(self):
         """Test save and load ImageGrid from NetCDF."""
         # Create test data
-        data = np.random.rand(50, 50)
+        rng = np.random.default_rng(0)
+        data = rng.random((50, 50))
         lat = np.linspace(38.0, 39.0, 50)
         lon = np.linspace(-116.0, -115.0, 50)
         lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
@@ -52,7 +53,8 @@ class TestImageGridSaveLoad:
     def test_mat_round_trip(self):
         """Test save and load ImageGrid from MATLAB .mat file."""
         # Create test data
-        data = np.random.rand(50, 50)
+        rng = np.random.default_rng(0)
+        data = rng.random((50, 50))
         lat = np.linspace(38.0, 39.0, 50)
         lon = np.linspace(-116.0, -115.0, 50)
         lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
@@ -80,7 +82,8 @@ class TestImageGridSaveLoad:
     def test_save_with_metadata(self):
         """Test saving ImageGrid with custom metadata."""
         # Create test data
-        data = np.random.rand(10, 10)
+        rng = np.random.default_rng(0)
+        data = rng.random((10, 10))
         lat = np.linspace(38.0, 39.0, 10)
         lon = np.linspace(-116.0, -115.0, 10)
         lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")
@@ -113,7 +116,8 @@ class TestImageGridSaveLoad:
 
     def test_invalid_format(self):
         """Test that invalid format raises ValueError."""
-        data = np.random.rand(10, 10)
+        rng = np.random.default_rng(0)
+        data = rng.random((10, 10))
         lat = np.linspace(38.0, 39.0, 10)
         lon = np.linspace(-116.0, -115.0, 10)
         lat_grid, lon_grid = np.meshgrid(lat, lon, indexing="ij")

--- a/tests/test_correction/test_regrid.py
+++ b/tests/test_correction/test_regrid.py
@@ -1,0 +1,348 @@
+"""Unit tests for regrid module.
+
+Tests for GCP chip regridding algorithms.
+"""
+
+import numpy as np
+import pytest
+
+from curryer.correction.data_structures import ImageGrid, RegridConfig
+from curryer.correction.regrid import (
+    bilinear_interpolate_quad,
+    compute_regular_grid_bounds,
+    create_regular_grid,
+    find_containing_cell,
+    point_in_triangle,
+    regrid_gcp_chip,
+    regrid_irregular_to_regular,
+)
+
+
+class TestRegridConfig:
+    """Test RegridConfig validation."""
+
+    def test_resolution_based_config(self):
+        """Test resolution-based configuration."""
+        config = RegridConfig(output_resolution_deg=(0.001, 0.001))
+        assert config.output_resolution_deg == (0.001, 0.001)
+        assert config.output_grid_size is None
+        assert config.conservative_bounds is True
+
+    def test_size_based_config(self):
+        """Test size-based configuration."""
+        config = RegridConfig(output_grid_size=(500, 500))
+        assert config.output_grid_size == (500, 500)
+        assert config.output_resolution_deg is None
+
+    def test_bounds_plus_resolution(self):
+        """Test bounds + resolution configuration."""
+        config = RegridConfig(output_bounds=(-116.0, -115.0, 38.0, 39.0), output_resolution_deg=(0.001, 0.001))
+        assert config.output_bounds is not None
+        assert config.output_resolution_deg is not None
+
+    def test_invalid_size_and_resolution(self):
+        """Test that size + resolution raises error."""
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            RegridConfig(output_grid_size=(500, 500), output_resolution_deg=(0.001, 0.001))
+
+    def test_invalid_bounds_without_resolution(self):
+        """Test that bounds without resolution raises error."""
+        with pytest.raises(ValueError, match="requires output_resolution_deg"):
+            RegridConfig(output_bounds=(-116.0, -115.0, 38.0, 39.0))
+
+    def test_invalid_interpolation_method(self):
+        """Test that invalid interpolation method raises error."""
+        with pytest.raises(ValueError, match="interpolation_method must be"):
+            RegridConfig(output_resolution_deg=(0.001, 0.001), interpolation_method="invalid")
+
+    def test_invalid_grid_size(self):
+        """Test that too-small grid size raises error."""
+        with pytest.raises(ValueError, match="at least 2 rows"):
+            RegridConfig(output_grid_size=(1, 100))
+
+    def test_invalid_resolution(self):
+        """Test that negative resolution raises error."""
+        with pytest.raises(ValueError, match="must be positive"):
+            RegridConfig(output_resolution_deg=(-0.001, 0.001))
+
+    def test_invalid_bounds(self):
+        """Test that invalid bounds raise error."""
+        with pytest.raises(ValueError, match="minlon must be < maxlon"):
+            RegridConfig(
+                output_bounds=(-115.0, -116.0, 38.0, 39.0),  # Swapped lon
+                output_resolution_deg=(0.001, 0.001),
+            )
+
+
+class TestGeometricPrimitives:
+    """Test geometric helper functions."""
+
+    def test_point_in_triangle_inside(self):
+        """Test point inside triangle."""
+        triangle = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]])
+        point = np.array([0.5, 0.3])
+
+        inside, weights = point_in_triangle(point, triangle)
+
+        assert inside
+        assert len(weights) == 3
+        assert np.abs(np.sum(weights) - 1.0) < 1e-10  # Weights sum to 1
+
+    def test_point_in_triangle_outside(self):
+        """Test point outside triangle."""
+        triangle = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]])
+        point = np.array([2.0, 2.0])
+
+        inside, weights = point_in_triangle(point, triangle)
+
+        assert not inside
+
+    def test_point_in_triangle_on_edge(self):
+        """Test point on triangle edge."""
+        triangle = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]])
+        point = np.array([0.5, 0.0])  # On base edge
+
+        inside, weights = point_in_triangle(point, triangle)
+
+        # With tolerant boundary check, point on edge should be inside
+        assert inside
+
+    def test_bilinear_interpolate_square(self):
+        """Test bilinear interpolation on a square."""
+        # Unit square with values at corners: 0, 1, 2, 3
+        corners_lon = np.array([0.0, 1.0, 1.0, 0.0])
+        corners_lat = np.array([1.0, 1.0, 0.0, 0.0])
+        corner_values = np.array([0.0, 1.0, 2.0, 3.0])
+
+        # Test center point
+        point = np.array([0.5, 0.5])
+        value = bilinear_interpolate_quad(point, corners_lon, corners_lat, corner_values)
+
+        # At center, should be average of corners
+        assert np.abs(value - 1.5) < 1e-10
+
+    def test_bilinear_interpolate_corner(self):
+        """Test bilinear interpolation at corner."""
+        corners_lon = np.array([0.0, 1.0, 1.0, 0.0])
+        corners_lat = np.array([1.0, 1.0, 0.0, 0.0])
+        corner_values = np.array([10.0, 20.0, 30.0, 40.0])
+
+        # Test at corner (should equal corner value)
+        point = np.array([0.0, 1.0])  # Top-left corner
+        value = bilinear_interpolate_quad(point, corners_lon, corners_lat, corner_values)
+
+        assert np.abs(value - 10.0) < 1e-6
+
+
+class TestGridOperations:
+    """Test grid creation and bounds computation."""
+
+    def test_compute_bounds_conservative(self):
+        """Test conservative bounds computation."""
+        # Create a slightly distorted grid
+        nrows, ncols = 10, 10
+        lat_base = np.linspace(39.0, 38.0, nrows)
+        lon_base = np.linspace(-116.0, -115.0, ncols)
+        lon_grid, lat_grid = np.meshgrid(lon_base, lat_base)
+
+        # Add small distortion
+        lon_grid += 0.01 * np.random.randn(nrows, ncols)
+        lat_grid += 0.01 * np.random.randn(nrows, ncols)
+
+        minlon, maxlon, minlat, maxlat = compute_regular_grid_bounds(lon_grid, lat_grid, conservative=True)
+
+        # Conservative bounds should be within full extent
+        assert minlon > lon_grid.min()
+        assert maxlon < lon_grid.max()
+        assert minlat > lat_grid.min()
+        assert maxlat < lat_grid.max()
+
+    def test_compute_bounds_full_extent(self):
+        """Test full extent bounds computation."""
+        nrows, ncols = 10, 10
+        lat_base = np.linspace(39.0, 38.0, nrows)
+        lon_base = np.linspace(-116.0, -115.0, ncols)
+        lon_grid, lat_grid = np.meshgrid(lon_base, lat_base)
+
+        minlon, maxlon, minlat, maxlat = compute_regular_grid_bounds(lon_grid, lat_grid, conservative=False)
+
+        # Full extent should match min/max
+        assert np.abs(minlon - lon_grid.min()) < 1e-10
+        assert np.abs(maxlon - lon_grid.max()) < 1e-10
+        assert np.abs(minlat - lat_grid.min()) < 1e-10
+        assert np.abs(maxlat - lat_grid.max()) < 1e-10
+
+    def test_create_regular_grid_from_size(self):
+        """Test regular grid creation from size."""
+        bounds = (-116.0, -115.0, 38.0, 39.0)
+        grid_size = (100, 100)
+
+        lon_grid, lat_grid = create_regular_grid(bounds, grid_size=grid_size)
+
+        assert lon_grid.shape == grid_size
+        assert lat_grid.shape == grid_size
+
+        # Check latitude decreases (row index increases going south)
+        assert lat_grid[0, 0] > lat_grid[-1, 0]
+
+        # Check longitude increases (col index increases going east)
+        assert lon_grid[0, 0] < lon_grid[0, -1]
+
+    def test_create_regular_grid_from_resolution(self):
+        """Test regular grid creation from resolution."""
+        bounds = (-116.0, -115.0, 38.0, 39.0)
+        resolution = (0.01, 0.01)  # 0.01 degree resolution
+
+        lon_grid, lat_grid = create_regular_grid(bounds, resolution=resolution)
+
+        # Check expected dimensions (1 degree / 0.01 + 1)
+        assert lon_grid.shape[0] == 101  # (39-38)/0.01 + 1
+        assert lon_grid.shape[1] == 101  # (-115-(-116))/0.01 + 1
+
+    def test_create_regular_grid_requires_one_param(self):
+        """Test that exactly one of size/resolution is required."""
+        bounds = (-116.0, -115.0, 38.0, 39.0)
+
+        # Neither provided
+        with pytest.raises(ValueError, match="Must specify either"):
+            create_regular_grid(bounds)
+
+        # Both provided
+        with pytest.raises(ValueError, match="only one of"):
+            create_regular_grid(bounds, grid_size=(100, 100), resolution=(0.01, 0.01))
+
+
+class TestRegridding:
+    """Test core regridding functionality."""
+
+    def test_find_containing_cell_simple(self):
+        """Test finding containing cell in regular grid."""
+        # Create simple regular grid
+        nrows, ncols = 5, 5
+        lat = np.linspace(39.0, 38.0, nrows)
+        lon = np.linspace(-116.0, -115.0, ncols)
+        lon_grid, lat_grid = np.meshgrid(lon, lat)
+
+        # Test point in center of cell [1, 1] (not on boundary)
+        # Cell [1,1] has corners: (-115.75, 38.75), (-115.5, 38.75),
+        #                         (-115.5, 38.5), (-115.75, 38.5)
+        point = np.array([-115.625, 38.625])  # Center of cell [1,1]
+        cell = find_containing_cell(point, lon_grid, lat_grid)
+
+        assert cell is not None
+        assert cell == (1, 1)
+
+    def test_find_containing_cell_outside(self):
+        """Test point outside grid returns None."""
+        nrows, ncols = 5, 5
+        lat = np.linspace(39.0, 38.0, nrows)
+        lon = np.linspace(-116.0, -115.0, ncols)
+        lon_grid, lat_grid = np.meshgrid(lon, lat)
+
+        # Test point way outside
+        point = np.array([-120.0, 40.0])
+        cell = find_containing_cell(point, lon_grid, lat_grid)
+
+        assert cell is None
+
+    def test_regrid_identity(self):
+        """Test that regridding to same grid preserves values."""
+        # Create regular grid
+        nrows, ncols = 10, 10
+        lat = np.linspace(39.0, 38.0, nrows)
+        lon = np.linspace(-116.0, -115.0, ncols)
+        lon_grid, lat_grid = np.meshgrid(lon, lat)
+
+        # Create simple data
+        data = np.arange(nrows * ncols).reshape(nrows, ncols).astype(float)
+
+        # Regrid to same grid
+        data_regridded = regrid_irregular_to_regular(data, lon_grid, lat_grid, lon_grid, lat_grid)
+
+        # Should be nearly identical
+        np.testing.assert_array_almost_equal(data, data_regridded, decimal=6)
+
+    def test_regrid_coarsen(self):
+        """Test regridding to coarser grid."""
+        # Create fine regular grid
+        nrows_fine, ncols_fine = 20, 20
+        lat_fine = np.linspace(39.0, 38.0, nrows_fine)
+        lon_fine = np.linspace(-116.0, -115.0, ncols_fine)
+        lon_grid_fine, lat_grid_fine = np.meshgrid(lon_fine, lat_fine)
+
+        # Create data with gradient
+        data_fine = lon_grid_fine + lat_grid_fine
+
+        # Create coarse grid
+        nrows_coarse, ncols_coarse = 5, 5
+        lat_coarse = np.linspace(39.0, 38.0, nrows_coarse)
+        lon_coarse = np.linspace(-116.0, -115.0, ncols_coarse)
+        lon_grid_coarse, lat_grid_coarse = np.meshgrid(lon_coarse, lat_coarse)
+
+        # Regrid
+        data_coarse = regrid_irregular_to_regular(
+            data_fine, lon_grid_fine, lat_grid_fine, lon_grid_coarse, lat_grid_coarse
+        )
+
+        # Check shape
+        assert data_coarse.shape == (nrows_coarse, ncols_coarse)
+
+        # Check no NaNs in interior
+        assert not np.any(np.isnan(data_coarse))
+
+        # Check values are in reasonable range (allow small numerical errors)
+        # Bilinear interpolation can produce values slightly outside original range
+        tol = 1e-10
+        assert data_coarse.min() >= data_fine.min() - tol
+        assert data_coarse.max() <= data_fine.max() + tol
+
+
+class TestEndToEnd:
+    """Test complete regridding workflow."""
+
+    def test_regrid_gcp_chip_synthetic(self):
+        """Test regrid_gcp_chip with synthetic data."""
+        # Create synthetic chip with ECEF coordinates
+        nrows, ncols = 50, 50
+
+        # Generate regular lat/lon grid
+        lat = np.linspace(38.5, 38.0, nrows)
+        lon = np.linspace(-116.0, -115.5, ncols)
+        lon_grid, lat_grid = np.meshgrid(lon, lat)
+
+        # Convert to ECEF (using simplified approach for testing)
+        # For real test, would use actual geodetic_to_ecef
+        from curryer.compute.spatial import geodetic_to_ecef
+
+        lla = np.stack([lon_grid.ravel(), lat_grid.ravel(), np.zeros(nrows * ncols)], axis=1)
+        ecef = geodetic_to_ecef(lla, meters=True, degrees=True)
+
+        ecef_x = ecef[:, 0].reshape(nrows, ncols)
+        ecef_y = ecef[:, 1].reshape(nrows, ncols)
+        ecef_z = ecef[:, 2].reshape(nrows, ncols)
+
+        # Create simple data pattern
+        band_data = np.arange(nrows * ncols).reshape(nrows, ncols).astype(float)
+
+        # Regrid to coarser resolution
+        config = RegridConfig(output_resolution_deg=(0.02, 0.02))  # Coarser
+
+        result = regrid_gcp_chip(band_data, (ecef_x, ecef_y, ecef_z), config)
+
+        # Check result is ImageGrid
+        assert isinstance(result, ImageGrid)
+
+        # Check output is smaller (coarser resolution)
+        assert result.data.shape[0] < nrows
+        assert result.data.shape[1] < ncols
+
+        # Check no NaNs in interior
+        assert not np.all(np.isnan(result.data))
+
+        # Check lat/lon grids are regular
+        lat_spacing = np.diff(result.lat[:, 0])
+        assert np.allclose(lat_spacing, lat_spacing[0], rtol=1e-6)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_correction/test_regrid.py
+++ b/tests/test_correction/test_regrid.py
@@ -152,11 +152,11 @@ class TestGridOperations:
 
         minlon, maxlon, minlat, maxlat = compute_regular_grid_bounds(lon_grid, lat_grid, conservative=True)
 
-        # Conservative bounds should be within full extent
-        assert minlon > lon_grid.min()
-        assert maxlon < lon_grid.max()
-        assert minlat > lat_grid.min()
-        assert maxlat < lat_grid.max()
+        # Conservative bounds should not extend beyond the full extent
+        assert minlon >= lon_grid.min()
+        assert maxlon <= lon_grid.max()
+        assert minlat >= lat_grid.min()
+        assert maxlat <= lat_grid.max()
 
     def test_compute_bounds_full_extent(self):
         """Test full extent bounds computation."""

--- a/tests/test_correction/test_regrid.py
+++ b/tests/test_correction/test_regrid.py
@@ -145,9 +145,10 @@ class TestGridOperations:
         lon_base = np.linspace(-116.0, -115.0, ncols)
         lon_grid, lat_grid = np.meshgrid(lon_base, lat_base)
 
-        # Add small distortion
-        lon_grid += 0.01 * np.random.randn(nrows, ncols)
-        lat_grid += 0.01 * np.random.randn(nrows, ncols)
+        # Add small, deterministic distortion using a fixed RNG seed
+        rng = np.random.default_rng(0)
+        lon_grid += 0.01 * rng.standard_normal(size=(nrows, ncols))
+        lat_grid += 0.01 * rng.standard_normal(size=(nrows, ncols))
 
         minlon, maxlon, minlat, maxlat = compute_regular_grid_bounds(lon_grid, lat_grid, conservative=True)
 


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the `image_io` and `regrid` modules, significantly increasing test coverage for I/O and regridding functionality. The new tests cover round-trip serialization, error handling, geometric primitives, grid operations, and end-to-end regridding workflows.

**New tests for image I/O functionality:**

* Added `tests/test_correction/test_image_io.py` with tests for round-trip saving and loading of `ImageGrid` objects using NetCDF and MATLAB formats, including metadata preservation and error handling for invalid formats and missing files.

**New tests for regridding algorithms:**

* Added `tests/test_correction/test_regrid.py` with tests for:
  - `RegridConfig` validation, including error cases for invalid configurations.
  - Geometric helper functions (`point_in_triangle`, `bilinear_interpolate_quad`).
  - Grid operations such as bounds computation and grid creation.
  - Core regridding logic including cell finding, interpolation, and identity/coarsening checks.
  - End-to-end regridding workflow using synthetic data and ECEF coordinate conversion.