### PR TITLE
pin spiceypy below 8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "requests>=2.28",
     "jinja2>=3",
     # NOTE: SpiceyPy 8.1+ breaks curryer compatibility. Keep this pin until
-    # that issue is resolved upstream/in curryer (add issue/PR reference here).
+    # that issue is resolved upstream/in curryer (CURRYER-148).
     "spiceypy>=6,<8.1.0",
     "openpyxl>=3",
     "numpy >=1.23,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "pyproj>=3.6",
     "requests>=2.28",
     "jinja2>=3",
+    # NOTE: SpiceyPy 8.1+ breaks curryer compatibility. Keep this pin until
+    # that issue is resolved upstream/in curryer (add issue/PR reference here).
     "spiceypy>=6,<8.1.0",
     "openpyxl>=3",
     "numpy >=1.23,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pyproj>=3.6",
     "requests>=2.28",
     "jinja2>=3",
-    "spiceypy>=6",
+    "spiceypy>=6, <8.1.0",
     "openpyxl>=3",
     "numpy >=1.23,<2.0",
     "boto3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pyproj>=3.6",
     "requests>=2.28",
     "jinja2>=3",
-    "spiceypy>=6, <8.1.0",
+    "spiceypy>=6,<8.1.0",
     "openpyxl>=3",
     "numpy >=1.23,<2.0",
     "boto3",


### PR DESCRIPTION
SpiceyPy 8.1 broke curryer. Patching this hot fix specifically to enable Libera SDC development.