### PR TITLE
LIBSDC-739 Adding new fields and Geometry.py Foundation (PR 1)

### DIFF
--- a/curryer/compute/__init__.py
+++ b/curryer/compute/__init__.py
@@ -1,6 +1,6 @@
 """Methods for computing spatial and pointing datasets.
 
-@author: Brandon Stone
+@author: Brandon Stone, Matthew Maclay
 """
 
 from . import constants, elevation, ephemeris, geometry, pointing, spatial

--- a/curryer/compute/__init__.py
+++ b/curryer/compute/__init__.py
@@ -3,6 +3,6 @@
 @author: Brandon Stone
 """
 
-from . import constants, elevation, ephemeris, pointing, spatial
+from . import constants, elevation, ephemeris, geometry, pointing, spatial
 
-__all__ = ["constants", "elevation", "ephemeris", "pointing", "spatial"]
+__all__ = ["constants", "elevation", "ephemeris", "geometry", "pointing", "spatial"]

--- a/curryer/compute/geometry.py
+++ b/curryer/compute/geometry.py
@@ -289,6 +289,14 @@ _FIELDS = {
 }
 
 
+# Providers needing only ephemeris (position) coverage -- no attitude (CK) or
+# instrument FOV. The default field set is every field computable from these alone,
+# so a no-`fields` request never implicitly pulls in attitude-derived fields (added
+# by later field groups) that would require additional kernels.
+_EPHEMERIS_PROVIDERS = frozenset({"sc_position", "sun_position"})
+_DEFAULT_FIELDS = tuple(name for name, field in _FIELDS.items() if field.providers <= _EPHEMERIS_PROVIDERS)
+
+
 class GeometryData(abstract.AbstractMissionData):
     """Selective geometric data-field server.
 
@@ -321,7 +329,7 @@ class GeometryData(abstract.AbstractMissionData):
 
     """
 
-    DEFAULT_CADENCE = constants.ATTITUDE_TIMESTEP_USEC
+    DEFAULT_CADENCE = constants.EPHEMERIS_TIMESTEP_USEC
 
     def __init__(self, observer, microsecond_cadence=None, earth="EARTH", sun="SUN", earth_frame=None):
         microsecond_cadence = self.DEFAULT_CADENCE if microsecond_cadence is None else microsecond_cadence
@@ -339,19 +347,35 @@ class GeometryData(abstract.AbstractMissionData):
         return tuple(_FIELDS)
 
     def _resolve_fields(self, fields):
-        """Validate the requested fields, defaulting to all registered."""
+        """Validate the requested fields, defaulting to the ephemeris-only set."""
         if fields is None:
-            return list(_FIELDS)
+            return list(_DEFAULT_FIELDS)
         unknown = [name for name in fields if name not in _FIELDS]
         if unknown:
             raise KeyError(f"Unknown geometry field(s): {unknown}. Available: {self.available_fields()}")
         return list(fields)
 
     def _gather_providers(self, fields, ugps_times):
-        """Query the minimal set of providers for ``fields``, once each."""
-        needed = set().union(*(_FIELDS[name].providers for name in fields))
-        logger.debug("Querying providers %s for fields %s", sorted(needed), fields)
-        return {key: _PROVIDERS[key](ugps_times, self) for key in needed}
+        """Query the minimal set of providers for ``fields``, once each.
+
+        Providers are evaluated in a stable (sorted) order so runs are
+        reproducible. A provider that returns all-NaN over the whole grid is the
+        documented missing-kernel signal, so it is logged as a warning.
+        """
+        needed = sorted(set().union(*(_FIELDS[name].providers for name in fields)))
+        logger.debug("Querying providers %s for fields %s", needed, fields)
+        providers = {}
+        for key in needed:
+            values = _PROVIDERS[key](ugps_times, self)
+            if np.size(values) and np.all(np.isnan(np.asarray(values, dtype=float))):
+                logger.warning(
+                    "Provider %r returned all-NaN over %d time(s); the required kernel is likely "
+                    "unfurnished for this interval.",
+                    key,
+                    len(ugps_times),
+                )
+            providers[key] = values
+        return providers
 
     @abstract.log_return()
     def get_geometry(self, ugps_times: np.ndarray, fields: list[str] | None = None) -> pd.DataFrame:
@@ -363,7 +387,8 @@ class GeometryData(abstract.AbstractMissionData):
             One or more times in GPS microseconds. Arbitrary and need not be
             uniformly spaced; each time is evaluated exactly (no interpolation).
         fields : list of str, optional
-            Field names to compute. Default is all registered fields.
+            Field names to compute. Default is the ephemeris-only set -- the
+            fields computable from position/ephemeris providers alone.
 
         Returns
         -------

--- a/curryer/compute/geometry.py
+++ b/curryer/compute/geometry.py
@@ -1,0 +1,352 @@
+"""Selective geometric data-field computation.
+
+This module computes the geolocation/geometry ancillary data fields the Level-1
+products require. It is organized in two layers, both mission-generic:
+
+- **Math-only leaf functions** (``sc_radius``, ``colatitude``,
+  ``subobserver_point``, ``earth_sun_distance``) -- pure, vectorized, SPICE-free.
+  They take high-level inputs (positions) as arguments and can be called directly
+  to compose custom fields; the coordinate/frame primitives they build on (e.g.
+  ``ecef_to_geodetic``) stay in :mod:`curryer.compute.spatial`.
+- **A selective-compute registry** -- a declarative map from each output field to
+  the SPICE-derived inputs ("providers") it needs. A caller requests an arbitrary
+  subset of fields and only the inputs that subset needs are queried, each
+  provider exactly once, never per-field. This is the pre-built convenience over
+  the leaf tools.
+
+Why a registry rather than one method per field: the field-to-input mapping is
+many-to-many and growing. The registry computes the minimal provider set for any
+requested subset automatically; the naive alternative (each field querying its
+own inputs) re-queries SPICE redundantly.
+
+Two public accessors are exposed on :class:`GeometryData`:
+
+- ``get_geometry(ugps_times, fields)`` -> :class:`pandas.DataFrame` -- the
+  primary, tabular API. Vector fields expand to per-field-prefixed columns.
+- ``get_vectors(ugps_times, fields)`` -> ``{field: (N, k) ndarray}`` -- the typed
+  sibling, addressed by field name rather than by string-built column prefixes.
+  This is the seam the correction verification/image-matching path adapts onto.
+
+Mission genericity: the observing body is the only mission input (a constructor
+argument); the instrument frame and boresight are resolved from it and the loaded
+kernels. Only universal identifiers (``EARTH``, ``SUN``, ``ITRF93``) appear in
+code -- no spacecraft/instrument names are hardcoded.
+
+Frame contract: ``sc_position`` is emitted in ITRF93 (ECEF), explicit and
+non-overridable, so two fields can never be combined in mismatched reference
+frames.
+"""
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from .. import spicierpy
+from . import abstract, constants, spatial
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Math-only leaf functions (the "tools" layer): pure, vectorized, SPICE-free.
+# Usable directly or composed by the registry below.
+# ---------------------------------------------------------------------------
+def sc_radius(observer_position: np.ndarray) -> np.ndarray:
+    """Distance of the observer from the body center (vectorized).
+
+    Implements the "radius of satellite from center of Earth" field (issue #65).
+
+    Parameters
+    ----------
+    observer_position : np.ndarray
+        Observer (e.g., spacecraft) positions in rectangular coordinates, shape
+        (..., 3). Units are arbitrary; the result is in the input's units.
+
+    Returns
+    -------
+    np.ndarray
+        Euclidean distance ``||position||`` per point, shape (...,).
+
+    """
+    observer_position = np.asarray(observer_position, dtype=float)
+    if observer_position.shape[-1] != 3:
+        raise ValueError("`observer_position` must have 3 values per point!")
+    return np.linalg.norm(observer_position, axis=-1)
+
+
+def colatitude(latitude: np.ndarray, degrees=True) -> np.ndarray:
+    """Convert geodetic latitude to colatitude (vectorized).
+
+    Colatitude is the complement of latitude (``90 - lat``), ranging from 0 at
+    the north pole to 180 at the south pole. Implements the surface-point
+    colatitude field (issue #60); also reused by the sub-point fields (issues
+    #58, #59).
+
+    Parameters
+    ----------
+    latitude : np.ndarray
+        Geodetic latitude.
+    degrees : bool, optional
+        If True (default), inputs and outputs are in degrees, otherwise radians.
+
+    Returns
+    -------
+    np.ndarray
+        Colatitude in the same units as the input.
+
+    """
+    quarter_turn = 90.0 if degrees else np.pi / 2
+    return quarter_turn - np.asarray(latitude, dtype=float)
+
+
+def subobserver_point(observer_position: np.ndarray, degrees=True) -> np.ndarray:
+    """Sub-observer geodetic latitude, longitude, and colatitude (vectorized).
+
+    The sub-observer point is the geodetic ground point directly beneath the
+    observer; it shares the observer's geodetic latitude and longitude. Generic
+    over the observing body: pass the spacecraft position for the sub-satellite
+    point (issue #58) or the Sun position for the sub-solar point (issue #59).
+
+    Parameters
+    ----------
+    observer_position : np.ndarray
+        Observer positions in ECEF rectangular coordinates (km), shape (..., 3).
+    degrees : bool, optional
+        If True (default), latitude/longitude/colatitude are in degrees,
+        otherwise radians. Longitude follows ``ecef_to_geodetic`` (-180 to 180).
+
+    Returns
+    -------
+    np.ndarray
+        Stacked ``[latitude, longitude, colatitude]``, shape (..., 3).
+
+    """
+    lla = spatial.ecef_to_geodetic(observer_position, meters=False, degrees=degrees)
+    lat = lla[..., 1]
+    lon = lla[..., 0]
+    colat = colatitude(lat, degrees=degrees)
+    return np.stack([lat, lon, colat], axis=-1)
+
+
+def earth_sun_distance(earth_sun_position: np.ndarray, au=True) -> np.ndarray:
+    """Distance between Earth and Sun (vectorized).
+
+    Implements the Earth-Sun distance field (issue #67). The input is the
+    Earth-to-Sun position vector (any frame, since only the magnitude is used).
+
+    Parameters
+    ----------
+    earth_sun_position : np.ndarray
+        Earth-to-Sun position in rectangular coordinates (km), shape (..., 3).
+    au : bool, optional
+        If True (default), return astronomical units, otherwise kilometers.
+
+    Returns
+    -------
+    np.ndarray
+        Earth-Sun distance per point, shape (...,).
+
+    """
+    distance = np.linalg.norm(np.asarray(earth_sun_position, dtype=float), axis=-1)
+    return distance / constants.KM_PER_ASTRONOMICAL_UNIT if au else distance
+
+
+@dataclass(frozen=True)
+class _Field:
+    """Registry entry for a single output field.
+
+    Parameters
+    ----------
+    providers : frozenset of str
+        Keys of the providers (high-level inputs) this field requires.
+    columns : tuple of str
+        Output column names. One column for scalar fields, three for vectors.
+    evaluate : Callable
+        Maps the gathered provider dict to an ``(N, len(columns))`` array.
+
+    """
+
+    providers: frozenset
+    columns: tuple
+    evaluate: Callable
+
+
+# ---------------------------------------------------------------------------
+# Providers: each queries SPICE once over the ugps grid and returns a cached
+# array. The observing body and frames come from the caller's ``GeometryData``.
+# ---------------------------------------------------------------------------
+def _provider_sc_position(ugps_times, ctx):
+    """Observer (spacecraft) position in ITRF93 (ECEF), shape (N, 3), km."""
+    state = spicierpy.ext.query_ephemeris(
+        ugps_times,
+        target=ctx.observer,
+        observer=ctx.earth,
+        ref_frame=ctx.earth_frame,
+        velocity=False,
+        allow_nans=ctx.allow_nans,
+    )
+    return state[list(spicierpy.ext.POSITION_COLUMNS)].values
+
+
+def _provider_sun_position(ugps_times, ctx):
+    """Earth-to-Sun position in ITRF93 (ECEF), shape (N, 3), km."""
+    state = spicierpy.ext.query_ephemeris(
+        ugps_times,
+        target=ctx.sun,
+        observer=ctx.earth,
+        ref_frame=ctx.earth_frame,
+        velocity=False,
+        allow_nans=ctx.allow_nans,
+    )
+    return state[list(spicierpy.ext.POSITION_COLUMNS)].values
+
+
+_PROVIDERS = {
+    "sc_position": _provider_sc_position,
+    "sun_position": _provider_sun_position,
+}
+
+
+_FIELDS = {
+    "sc_radius": _Field(
+        providers=frozenset({"sc_position"}),
+        columns=("scradius",),
+        evaluate=lambda p: sc_radius(p["sc_position"])[:, None],
+    ),
+    "subsatellite": _Field(
+        providers=frozenset({"sc_position"}),
+        columns=("subsatlat", "subsatlon", "subsatcolat"),
+        evaluate=lambda p: subobserver_point(p["sc_position"]),
+    ),
+    "subsolar": _Field(
+        providers=frozenset({"sun_position"}),
+        columns=("subsollat", "subsollon", "subsolcolat"),
+        evaluate=lambda p: subobserver_point(p["sun_position"]),
+    ),
+    "earth_sun_distance": _Field(
+        providers=frozenset({"sun_position"}),
+        columns=("earthsundist",),
+        evaluate=lambda p: earth_sun_distance(p["sun_position"])[:, None],
+    ),
+    "sc_position": _Field(
+        providers=frozenset({"sc_position"}),
+        columns=("scx", "scy", "scz"),
+        evaluate=lambda p: p["sc_position"],
+    ),
+}
+
+
+class GeometryData(abstract.AbstractMissionData):
+    """Selective geometric data-field server.
+
+    Construct with the observing body, then request any subset of registered
+    fields via :meth:`get_geometry` (DataFrame) or :meth:`get_vectors` (typed
+    ``{field: ndarray}``). Only the SPICE inputs the requested subset needs are
+    queried, each exactly once. Relevant kernels must already be loaded for the
+    requested times, mirroring the other ``compute`` servers.
+
+    Parameters
+    ----------
+    observer : str or int or spicierpy.obj.Body
+        Observing body whose position (and, for later attitude-derived fields,
+        boresight) is queried -- typically the instrument or spacecraft.
+    microsecond_cadence : int, optional
+        Default cadence for :meth:`get_times`, in microseconds.
+    earth, sun : str or int or spicierpy.obj.Body, optional
+        Central body and solar body for the ephemeris queries. Default
+        ``"EARTH"`` / ``"SUN"``; overridable so no body name is fixed in code.
+    earth_frame : str or spicierpy.obj.Frame, optional
+        Earth-fixed (ECEF) reference frame. Default ``spatial.EARTH_FRAME``
+        (ITRF93).
+
+    """
+
+    DEFAULT_CADENCE = constants.ATTITUDE_TIMESTEP_USEC
+
+    def __init__(self, observer, microsecond_cadence=None, earth="EARTH", sun="SUN", earth_frame=None):
+        microsecond_cadence = self.DEFAULT_CADENCE if microsecond_cadence is None else microsecond_cadence
+        super().__init__(microsecond_cadence=microsecond_cadence)
+        # Store raw names; SPICE objects are resolved lazily inside the providers
+        # (within the caller's loaded-kernel context), matching the other servers.
+        self.observer = observer
+        self.earth = earth
+        self.sun = sun
+        self.earth_frame = spatial.EARTH_FRAME if earth_frame is None else earth_frame
+
+    @classmethod
+    def available_fields(cls):
+        """Tuple of registered field names."""
+        return tuple(_FIELDS)
+
+    def _resolve_fields(self, fields):
+        """Validate the requested fields, defaulting to all registered."""
+        if fields is None:
+            return list(_FIELDS)
+        unknown = [name for name in fields if name not in _FIELDS]
+        if unknown:
+            raise KeyError(f"Unknown geometry field(s): {unknown}. Available: {self.available_fields()}")
+        return list(fields)
+
+    def _gather_providers(self, fields, ugps_times):
+        """Query the minimal set of providers for ``fields``, once each."""
+        needed = set().union(*(_FIELDS[name].providers for name in fields))
+        logger.debug("Querying providers %s for fields %s", sorted(needed), fields)
+        return {key: _PROVIDERS[key](ugps_times, self) for key in needed}
+
+    @abstract.log_return()
+    def get_geometry(self, ugps_times, fields=None) -> pd.DataFrame:
+        """Compute the requested fields as a table.
+
+        Parameters
+        ----------
+        ugps_times : array_like of int
+            One or more times in GPS microseconds.
+        fields : list of str, optional
+            Field names to compute. Default is all registered fields.
+
+        Returns
+        -------
+        pandas.DataFrame
+            One row per time (index ``ugps``); vector fields expand to
+            per-field-prefixed columns (e.g. ``scx, scy, scz``).
+
+        """
+        ugps_times = np.atleast_1d(np.asarray(ugps_times))
+        fields = self._resolve_fields(fields)
+        providers = self._gather_providers(fields, ugps_times)
+
+        data = {}
+        for name in fields:
+            field = _FIELDS[name]
+            values = np.asarray(field.evaluate(providers), dtype=float)
+            for jth, column in enumerate(field.columns):
+                data[column] = values[:, jth]
+        return pd.DataFrame(data, index=pd.Index(ugps_times, name="ugps"))
+
+    def get_vectors(self, ugps_times, fields) -> dict:
+        """Compute the requested fields as typed arrays.
+
+        The typed sibling of :meth:`get_geometry`, addressed by field name -- the
+        seam the correction verification/image-matching path adapts onto.
+
+        Parameters
+        ----------
+        ugps_times : array_like of int
+            One or more times in GPS microseconds.
+        fields : list of str
+            Field names to compute.
+
+        Returns
+        -------
+        dict of {str: numpy.ndarray}
+            Maps each field name to its ``(N, k)`` array. Vector fields
+            (e.g. ``sc_position``) are ``(N, 3)`` in ITRF93.
+
+        """
+        ugps_times = np.atleast_1d(np.asarray(ugps_times))
+        fields = self._resolve_fields(fields)
+        providers = self._gather_providers(fields, ugps_times)
+        return {name: np.asarray(_FIELDS[name].evaluate(providers), dtype=float) for name in fields}

--- a/curryer/compute/geometry.py
+++ b/curryer/compute/geometry.py
@@ -25,7 +25,6 @@ Two public accessors are exposed on :class:`GeometryData`:
   primary, tabular API. Vector fields expand to per-field-prefixed columns.
 - ``get_vectors(ugps_times, fields)`` -> ``{field: (N, k) ndarray}`` -- the typed
   sibling, addressed by field name rather than by string-built column prefixes.
-  This is the seam the correction verification/image-matching path adapts onto.
 
 Mission genericity: the observing body is the only mission input (a constructor
 argument). Only universal identifiers (``EARTH``, ``SUN``, ``ITRF93``) appear in
@@ -258,8 +257,8 @@ class GeometryData(abstract.AbstractMissionData):
     Parameters
     ----------
     observer : str or int or spicierpy.obj.Body
-        Observing body whose position (and, for later attitude-derived fields,
-        boresight) is queried -- typically the instrument or spacecraft.
+        Observing body whose position is queried -- typically the instrument or
+        spacecraft.
     microsecond_cadence : int, optional
         Default cadence for :meth:`get_times`, in microseconds.
     earth, sun : str or int or spicierpy.obj.Body, optional
@@ -338,8 +337,8 @@ class GeometryData(abstract.AbstractMissionData):
     def get_vectors(self, ugps_times, fields) -> dict:
         """Compute the requested fields as typed arrays.
 
-        The typed sibling of :meth:`get_geometry`, addressed by field name -- the
-        seam the correction verification/image-matching path adapts onto.
+        The typed sibling of :meth:`get_geometry`, addressed by field name rather
+        than by string-built column prefixes.
 
         Parameters
         ----------

--- a/curryer/compute/geometry.py
+++ b/curryer/compute/geometry.py
@@ -1,7 +1,8 @@
 """Selective geometric data-field computation.
 
-This module computes the geolocation/geometry ancillary data fields the Level-1
-products require. It is organized in two layers, both mission-generic:
+This module computes the geolocation/geometry ancillary data fields that
+geolocated products commonly need. It is organized in two layers, both
+mission-generic:
 
 - **Math-only leaf functions** (``sc_radius``, ``colatitude``,
   ``subobserver_point``, ``earth_sun_distance``) -- pure, vectorized, SPICE-free.
@@ -40,6 +41,18 @@ yields a NaN provider row; the math-only leaves are pure and propagate NaN
 elementwise, so every field is NaN on exactly the rows its inputs are missing and
 finite elsewhere -- per time, per field. Downstream maps those NaNs onto the
 product ``_FillValue`` (e.g. -999); the rows are never dropped or back-filled.
+
+Available fields: request any by name (``GeometryData.available_fields()`` lists
+them). Each field expands to the columns below.
+
+- ``sc_radius`` -> ``spacecraft_radius`` -- observer distance from Earth center.
+- ``subsatellite`` -> ``subsatellite_latitude``, ``subsatellite_longitude``,
+  ``subsatellite_colatitude`` -- ground point beneath the spacecraft.
+- ``subsolar`` -> ``subsolar_latitude``, ``subsolar_longitude``,
+  ``subsolar_colatitude`` -- ground point beneath the Sun.
+- ``earth_sun_distance`` -> ``earth_sun_distance`` -- Earth-Sun distance (AU).
+- ``sc_position`` -> ``spacecraft_position_x``, ``spacecraft_position_y``,
+  ``spacecraft_position_z`` -- spacecraft position (ECEF).
 """
 
 import logging
@@ -219,27 +232,27 @@ _PROVIDERS = {
 _FIELDS = {
     "sc_radius": _Field(
         providers=frozenset({"sc_position"}),
-        columns=("scradius",),
+        columns=("spacecraft_radius",),
         evaluate=lambda p: sc_radius(p["sc_position"])[:, None],
     ),
     "subsatellite": _Field(
         providers=frozenset({"sc_position"}),
-        columns=("subsatlat", "subsatlon", "subsatcolat"),
+        columns=("subsatellite_latitude", "subsatellite_longitude", "subsatellite_colatitude"),
         evaluate=lambda p: subobserver_point(p["sc_position"]),
     ),
     "subsolar": _Field(
         providers=frozenset({"sun_position"}),
-        columns=("subsollat", "subsollon", "subsolcolat"),
+        columns=("subsolar_latitude", "subsolar_longitude", "subsolar_colatitude"),
         evaluate=lambda p: subobserver_point(p["sun_position"]),
     ),
     "earth_sun_distance": _Field(
         providers=frozenset({"sun_position"}),
-        columns=("earthsundist",),
+        columns=("earth_sun_distance",),
         evaluate=lambda p: earth_sun_distance(p["sun_position"])[:, None],
     ),
     "sc_position": _Field(
         providers=frozenset({"sc_position"}),
-        columns=("scx", "scy", "scz"),
+        columns=("spacecraft_position_x", "spacecraft_position_y", "spacecraft_position_z"),
         evaluate=lambda p: p["sc_position"],
     ),
 }
@@ -253,6 +266,13 @@ class GeometryData(abstract.AbstractMissionData):
     ``{field: ndarray}``). Only the SPICE inputs the requested subset needs are
     queried, each exactly once. Relevant kernels must already be loaded for the
     requested times, mirroring the other ``compute`` servers.
+
+    The requested times are the independent variable: :meth:`get_geometry` and
+    :meth:`get_vectors` evaluate every field at exactly the ``ugps_times`` passed
+    -- an arbitrary, possibly non-uniform array -- with no resampling or
+    interpolation. ``microsecond_cadence`` / :meth:`get_times` only offers an
+    optional uniform grid for callers that want one; it never constrains which
+    times are queried.
 
     Parameters
     ----------
@@ -309,7 +329,8 @@ class GeometryData(abstract.AbstractMissionData):
         Parameters
         ----------
         ugps_times : array_like of int
-            One or more times in GPS microseconds.
+            One or more times in GPS microseconds. Arbitrary and need not be
+            uniformly spaced; each time is evaluated exactly (no interpolation).
         fields : list of str, optional
             Field names to compute. Default is all registered fields.
 
@@ -317,9 +338,10 @@ class GeometryData(abstract.AbstractMissionData):
         -------
         pandas.DataFrame
             One row per time (index ``ugps``); vector fields expand to
-            per-field-prefixed columns (e.g. ``scx, scy, scz``). Times outside
-            SPICE coverage are NaN across that field's columns (see the module
-            Fill contract).
+            per-field-prefixed columns (e.g. ``spacecraft_position_x,
+            spacecraft_position_y, spacecraft_position_z``). Times outside SPICE
+            coverage are NaN across that field's columns (see the module Fill
+            contract).
 
         """
         ugps_times = np.atleast_1d(np.asarray(ugps_times))
@@ -343,7 +365,8 @@ class GeometryData(abstract.AbstractMissionData):
         Parameters
         ----------
         ugps_times : array_like of int
-            One or more times in GPS microseconds.
+            One or more times in GPS microseconds. Arbitrary and need not be
+            uniformly spaced; each time is evaluated exactly (no interpolation).
         fields : list of str
             Field names to compute.
 

--- a/curryer/compute/geometry.py
+++ b/curryer/compute/geometry.py
@@ -28,13 +28,12 @@ Two public accessors are exposed on :class:`GeometryData`:
   This is the seam the correction verification/image-matching path adapts onto.
 
 Mission genericity: the observing body is the only mission input (a constructor
-argument); the instrument frame and boresight are resolved from it and the loaded
-kernels. Only universal identifiers (``EARTH``, ``SUN``, ``ITRF93``) appear in
+argument). Only universal identifiers (``EARTH``, ``SUN``, ``ITRF93``) appear in
 code -- no spacecraft/instrument names are hardcoded.
 
-Frame contract: ``sc_position`` is emitted in ITRF93 (ECEF), explicit and
-non-overridable, so two fields can never be combined in mismatched reference
-frames.
+Frame contract: the Earth-fixed (ECEF) fields all share a single reference frame
+-- the ``earth_frame`` configured on :class:`GeometryData` (``ITRF93`` by
+default) -- so fields are never combined in mismatched reference frames.
 
 Fill contract: SPICE coverage gaps (and off-Earth samples) surface as NaN. The
 providers query with ``allow_nans`` (True by default), so an uncovered time
@@ -64,7 +63,7 @@ logger = logging.getLogger(__name__)
 def sc_radius(observer_position: np.ndarray) -> np.ndarray:
     """Distance of the observer from the body center (vectorized).
 
-    Implements the "radius of satellite from center of Earth" field (issue #65).
+    Implements the "radius of satellite from center of Earth" field.
 
     Parameters
     ----------
@@ -89,8 +88,7 @@ def colatitude(latitude: np.ndarray, degrees=True) -> np.ndarray:
 
     Colatitude is the complement of latitude (``90 - lat``), ranging from 0 at
     the north pole to 180 at the south pole. Implements the surface-point
-    colatitude field (issue #60); also reused by the sub-point fields (issues
-    #58, #59).
+    colatitude field; also reused by the sub-point fields.
 
     Parameters
     ----------
@@ -115,7 +113,7 @@ def subobserver_point(observer_position: np.ndarray, degrees=True) -> np.ndarray
     The sub-observer point is the geodetic ground point directly beneath the
     observer; it shares the observer's geodetic latitude and longitude. Generic
     over the observing body: pass the spacecraft position for the sub-satellite
-    point (issue #58) or the Sun position for the sub-solar point (issue #59).
+    point or the Sun position for the sub-solar point.
 
     Parameters
     ----------
@@ -141,7 +139,7 @@ def subobserver_point(observer_position: np.ndarray, degrees=True) -> np.ndarray
 def earth_sun_distance(earth_sun_position: np.ndarray, au=True) -> np.ndarray:
     """Distance between Earth and Sun (vectorized).
 
-    Implements the Earth-Sun distance field (issue #67). The input is the
+    Implements the Earth-Sun distance field. The input is the
     Earth-to-Sun position vector (any frame, since only the magnitude is used).
 
     Parameters
@@ -186,7 +184,8 @@ class _Field:
 # array. The observing body and frames come from the caller's ``GeometryData``.
 # ---------------------------------------------------------------------------
 def _provider_sc_position(ugps_times, ctx):
-    """Observer (spacecraft) position in ITRF93 (ECEF), shape (N, 3), km."""
+    """Observer (spacecraft) position in the configured Earth-fixed frame
+    (``ctx.earth_frame``, ``ITRF93`` by default), shape (N, 3), km."""
     state = spicierpy.ext.query_ephemeris(
         ugps_times,
         target=ctx.observer,
@@ -199,7 +198,8 @@ def _provider_sc_position(ugps_times, ctx):
 
 
 def _provider_sun_position(ugps_times, ctx):
-    """Earth-to-Sun position in ITRF93 (ECEF), shape (N, 3), km."""
+    """Earth-to-Sun position in the configured Earth-fixed frame
+    (``ctx.earth_frame``, ``ITRF93`` by default), shape (N, 3), km."""
     state = spicierpy.ext.query_ephemeris(
         ugps_times,
         target=ctx.sun,
@@ -352,8 +352,9 @@ class GeometryData(abstract.AbstractMissionData):
         -------
         dict of {str: numpy.ndarray}
             Maps each field name to its ``(N, k)`` array. Vector fields
-            (e.g. ``sc_position``) are ``(N, 3)`` in ITRF93. Rows outside SPICE
-            coverage are NaN (see the module Fill contract).
+            (e.g. ``sc_position``) are ``(N, 3)`` in the configured Earth-fixed
+            frame (``ITRF93`` by default). Rows outside SPICE coverage are NaN
+            (see the module Fill contract).
 
         """
         ugps_times = np.atleast_1d(np.asarray(ugps_times))

--- a/curryer/compute/geometry.py
+++ b/curryer/compute/geometry.py
@@ -5,7 +5,8 @@ geolocated products commonly need. It is organized in two layers, both
 mission-generic:
 
 - **Math-only leaf functions** (``sc_radius``, ``colatitude``,
-  ``subobserver_point``, ``earth_sun_distance``) -- pure, vectorized, SPICE-free.
+  ``subobserver_point``, ``earth_sun_distance``, ``satellite_altitude``) -- pure,
+  vectorized, SPICE-free.
   They take high-level inputs (positions) as arguments and can be called directly
   to compose custom fields; the coordinate/frame primitives they build on (e.g.
   ``ecef_to_geodetic``) stay in :mod:`curryer.compute.spatial`.
@@ -53,6 +54,8 @@ them). Each field expands to the columns below.
 - ``earth_sun_distance`` -> ``earth_sun_distance`` -- Earth-Sun distance (AU).
 - ``sc_position`` -> ``spacecraft_position_x``, ``spacecraft_position_y``,
   ``spacecraft_position_z`` -- spacecraft position (ECEF).
+- ``sc_altitude`` -> ``spacecraft_altitude`` -- observer geodetic height above the
+  ellipsoid (km).
 """
 
 import logging
@@ -171,6 +174,29 @@ def earth_sun_distance(earth_sun_position: np.ndarray, au=True) -> np.ndarray:
     return distance / constants.KM_PER_ASTRONOMICAL_UNIT if au else distance
 
 
+def satellite_altitude(observer_position: np.ndarray) -> np.ndarray:
+    """Geodetic altitude of the observer above the ellipsoid (vectorized).
+
+    The height-above-ellipsoid component of the observer's geodetic position -- the
+    piece ``subobserver_point`` drops when it returns latitude/longitude/colatitude.
+    Complements ``sc_radius`` (the geocentric distance from the body center).
+
+    Parameters
+    ----------
+    observer_position : np.ndarray
+        Observer (e.g., spacecraft) positions in ECEF rectangular coordinates (km),
+        shape (..., 3).
+
+    Returns
+    -------
+    np.ndarray
+        Geodetic altitude in km, shape (...,).
+
+    """
+    lla = spatial.ecef_to_geodetic(observer_position, meters=False, degrees=True)
+    return lla[..., 2]
+
+
 @dataclass(frozen=True)
 class _Field:
     """Registry entry for a single output field.
@@ -254,6 +280,11 @@ _FIELDS = {
         providers=frozenset({"sc_position"}),
         columns=("spacecraft_position_x", "spacecraft_position_y", "spacecraft_position_z"),
         evaluate=lambda p: p["sc_position"],
+    ),
+    "sc_altitude": _Field(
+        providers=frozenset({"sc_position"}),
+        columns=("spacecraft_altitude",),
+        evaluate=lambda p: satellite_altitude(p["sc_position"])[:, None],
     ),
 }
 

--- a/curryer/compute/geometry.py
+++ b/curryer/compute/geometry.py
@@ -98,7 +98,7 @@ def sc_radius(observer_position: np.ndarray) -> np.ndarray:
     return np.linalg.norm(observer_position, axis=-1)
 
 
-def colatitude(latitude: np.ndarray, degrees=True) -> np.ndarray:
+def colatitude(latitude: np.ndarray, degrees: bool = True) -> np.ndarray:
     """Convert geodetic latitude to colatitude (vectorized).
 
     Colatitude is the complement of latitude (``90 - lat``), ranging from 0 at
@@ -122,7 +122,7 @@ def colatitude(latitude: np.ndarray, degrees=True) -> np.ndarray:
     return quarter_turn - np.asarray(latitude, dtype=float)
 
 
-def subobserver_point(observer_position: np.ndarray, degrees=True) -> np.ndarray:
+def subobserver_point(observer_position: np.ndarray, degrees: bool = True) -> np.ndarray:
     """Sub-observer geodetic latitude, longitude, and colatitude (vectorized).
 
     The sub-observer point is the geodetic ground point directly beneath the
@@ -151,7 +151,7 @@ def subobserver_point(observer_position: np.ndarray, degrees=True) -> np.ndarray
     return np.stack([lat, lon, colat], axis=-1)
 
 
-def earth_sun_distance(earth_sun_position: np.ndarray, au=True) -> np.ndarray:
+def earth_sun_distance(earth_sun_position: np.ndarray, au: bool = True) -> np.ndarray:
     """Distance between Earth and Sun (vectorized).
 
     Implements the Earth-Sun distance field. The input is the
@@ -212,9 +212,9 @@ class _Field:
 
     """
 
-    providers: frozenset
-    columns: tuple
-    evaluate: Callable
+    providers: frozenset[str]
+    columns: tuple[str, ...]
+    evaluate: Callable[[dict], np.ndarray]
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +354,7 @@ class GeometryData(abstract.AbstractMissionData):
         return {key: _PROVIDERS[key](ugps_times, self) for key in needed}
 
     @abstract.log_return()
-    def get_geometry(self, ugps_times, fields=None) -> pd.DataFrame:
+    def get_geometry(self, ugps_times: np.ndarray, fields: list[str] | None = None) -> pd.DataFrame:
         """Compute the requested fields as a table.
 
         Parameters
@@ -387,7 +387,7 @@ class GeometryData(abstract.AbstractMissionData):
                 data[column] = values[:, jth]
         return pd.DataFrame(data, index=pd.Index(ugps_times, name="ugps"))
 
-    def get_vectors(self, ugps_times, fields) -> dict:
+    def get_vectors(self, ugps_times: np.ndarray, fields: list[str]) -> dict[str, np.ndarray]:
         """Compute the requested fields as typed arrays.
 
         The typed sibling of :meth:`get_geometry`, addressed by field name rather

--- a/curryer/compute/geometry.py
+++ b/curryer/compute/geometry.py
@@ -35,6 +35,13 @@ code -- no spacecraft/instrument names are hardcoded.
 Frame contract: ``sc_position`` is emitted in ITRF93 (ECEF), explicit and
 non-overridable, so two fields can never be combined in mismatched reference
 frames.
+
+Fill contract: SPICE coverage gaps (and off-Earth samples) surface as NaN. The
+providers query with ``allow_nans`` (True by default), so an uncovered time
+yields a NaN provider row; the math-only leaves are pure and propagate NaN
+elementwise, so every field is NaN on exactly the rows its inputs are missing and
+finite elsewhere -- per time, per field. Downstream maps those NaNs onto the
+product ``_FillValue`` (e.g. -999); the rows are never dropped or back-filled.
 """
 
 import logging
@@ -311,7 +318,9 @@ class GeometryData(abstract.AbstractMissionData):
         -------
         pandas.DataFrame
             One row per time (index ``ugps``); vector fields expand to
-            per-field-prefixed columns (e.g. ``scx, scy, scz``).
+            per-field-prefixed columns (e.g. ``scx, scy, scz``). Times outside
+            SPICE coverage are NaN across that field's columns (see the module
+            Fill contract).
 
         """
         ugps_times = np.atleast_1d(np.asarray(ugps_times))
@@ -343,7 +352,8 @@ class GeometryData(abstract.AbstractMissionData):
         -------
         dict of {str: numpy.ndarray}
             Maps each field name to its ``(N, k)`` array. Vector fields
-            (e.g. ``sc_position``) are ``(N, 3)`` in ITRF93.
+            (e.g. ``sc_position``) are ``(N, 3)`` in ITRF93. Rows outside SPICE
+            coverage are NaN (see the module Fill contract).
 
         """
         ugps_times = np.atleast_1d(np.asarray(ugps_times))

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Version 0.3.3 (2026-06)
+
+- Added the `curryer.compute.geometry` module: `GeometryData` computes geolocation/geometry
+  ancillary fields (subsatellite and subsolar points, satellite radius, Earth-Sun distance,
+  spacecraft position and geodetic altitude) through a selective-compute registry that queries
+  each SPICE input once, with importable math-only leaf functions and a documented per-field NaN
+  fill contract
+- Added frame-to-frame rotation primitives to `curryer.compute.spatial`: `frame_to_frame_rotation`,
+  `frame_to_frame_euler`, and `frame_to_frame_quaternion`
+
+## Version 0.3.2 (2026-04)
+
+- Pinned SpiceyPy below 8.1.0 for compatibility
+- Refreshed the documentation
+
+## Version 0.3.1 (2026-02)
+
+- Added a citation file
+
 ## Version 0.3.0
 
 - Add automatic SPICE file path shortening tools

--- a/docs/source/users.md
+++ b/docs/source/users.md
@@ -194,6 +194,90 @@ with curryer.spicierpy.ext.load_kernel([mkrn.sds_kernels, mkrn.mission_kernels])
 _Assumes dynamic kernels have been created and their file names defined within
 the metakernel JSON file._
 
+### Geometry Ancillary Fields
+
+{py:class}`~curryer.compute.geometry.GeometryData` computes the geolocation/geometry
+ancillary fields a Level-1 product needs — sub-satellite / sub-solar point, satellite
+radius and altitude, Earth-Sun distance (and, with attitude kernels, viewing/solar
+angles). You request any subset of fields by name and it queries the minimal set of
+SPICE inputs, each exactly once. The {py:mod}`curryer.compute.geometry` API reference
+documents every field, leaf function, and accessor.
+
+```python
+import pandas as pd
+import curryer
+from curryer.compute import geometry
+
+meta_kernel = 'tests/data/clarreo/cprs_v01.kernels.tm.json'
+generic_dir = 'data/generic'
+mkrn = curryer.meta.MetaKernel.from_json(meta_kernel, relative=True, sds_dir=generic_dir)
+
+time_range = ('2023-01-01', '2023-01-01T00:05:00')
+ugps_times = curryer.spicetime.adapt(pd.date_range(*time_range, freq='1s', inclusive='left'), 'iso')
+
+# Construct with the observing body (spacecraft or instrument). Kernels must be
+# furnished for the requested times -- GeometryData does not load them itself.
+geo = geometry.GeometryData('CPRS_HYSICS')
+with curryer.spicierpy.ext.load_kernel([mkrn.sds_kernels, mkrn.mission_kernels]):
+    df = geo.get_geometry(ugps_times, fields=['subsatellite', 'sc_radius', 'earth_sun_distance'])
+
+print(df.columns.tolist())
+# ['subsatellite_latitude', 'subsatellite_longitude', 'subsatellite_colatitude',
+#  'spacecraft_radius', 'earth_sun_distance']
+```
+
+For typed, per-field arrays instead of a flat table, use
+{py:meth}`~curryer.compute.geometry.GeometryData.get_vectors`:
+
+```python
+with curryer.spicierpy.ext.load_kernel([mkrn.sds_kernels, mkrn.mission_kernels]):
+    vectors = geo.get_vectors(ugps_times, fields=['sc_position', 'subsatellite'])
+
+vectors['sc_position'].shape   # (N, 3) ECEF position, km
+vectors['subsatellite'].shape  # (N, 3) latitude / longitude / colatitude
+```
+
+Things worth knowing:
+
+- **Times** are uGPS (`int64` microseconds since 1980-01-06); convert with
+  `curryer.spicetime.adapt(...)`. The times you pass are evaluated exactly — no
+  resampling or interpolation.
+- **Observer** is the only mission input. Position-derived fields work for any body;
+  attitude fields (e.g. `boresight`) need an instrument with a defined FOV.
+- **Discover fields** with
+  {py:meth}`~curryer.compute.geometry.GeometryData.available_fields`; the table below
+  (and the {py:mod}`module docstring <curryer.compute.geometry>`) lists each field and
+  the columns it expands to.
+- **Default** — {py:meth}`~curryer.compute.geometry.GeometryData.get_geometry` with no
+  `fields` returns the ephemeris-only set, valid for any observer (it skips the
+  per-sample attitude loop).
+- **Coverage gaps** surface as `NaN` (rows are never dropped); a provider that returns
+  all-NaN logs a warning — usually an unfurnished kernel. Pass `allow_nans=False` to
+  raise instead.
+- **Typed access** — {py:meth}`~curryer.compute.geometry.GeometryData.get_vectors`
+  returns `{field: (N, k) ndarray}` addressed by field name rather than column strings.
+
+| Field                | Columns                                              | Meaning                                      |
+| -------------------- | ---------------------------------------------------- | -------------------------------------------- |
+| `subsatellite`       | `subsatellite_latitude`, `_longitude`, `_colatitude` | Ground point beneath the spacecraft          |
+| `subsolar`           | `subsolar_latitude`, `_longitude`, `_colatitude`     | Ground point beneath the Sun                 |
+| `sc_radius`          | `spacecraft_radius`                                  | Geocentric distance from Earth's center (km) |
+| `sc_altitude`        | `spacecraft_altitude`                                | Geodetic height above the ellipsoid (km)     |
+| `earth_sun_distance` | `earth_sun_distance`                                 | Earth-Sun distance (AU)                      |
+| `sc_position`        | `spacecraft_position_x` / `_y` / `_z`                | Spacecraft position in ECEF (km)             |
+
+**Composing custom fields.** The registry is built on pure, SPICE-free leaf functions
+— {py:func}`~curryer.compute.geometry.subobserver_point`,
+{py:func}`~curryer.compute.geometry.sc_radius`,
+{py:func}`~curryer.compute.geometry.satellite_altitude`,
+{py:func}`~curryer.compute.geometry.colatitude`, and
+{py:func}`~curryer.compute.geometry.earth_sun_distance` — that take positions as
+arguments. Call them directly to derive fields the registry does not expose yet.
+
+Additional attitude-derived fields (instrument boresight, viewing/solar zenith and
+azimuth, cone angle) are added by the later geometry field groups and require an
+instrument FOV plus attitude (CK) coverage.
+
 ---
 
 ## SPICE Path Length Handling

--- a/docs/source/users.md
+++ b/docs/source/users.md
@@ -252,8 +252,8 @@ Things worth knowing:
   `fields` returns the ephemeris-only set, valid for any observer (it skips the
   per-sample attitude loop).
 - **Coverage gaps** surface as `NaN` (rows are never dropped); a provider that returns
-  all-NaN logs a warning — usually an unfurnished kernel. Pass `allow_nans=False` to
-  raise instead.
+  all-NaN logs a warning — usually an unfurnished kernel. Set `geo.allow_nans = False`
+  (an instance attribute) to raise instead.
 - **Typed access** — {py:meth}`~curryer.compute.geometry.GeometryData.get_vectors`
   returns `{field: (N, k) ndarray}` addressed by field name rather than column strings.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lasp-curryer"
-version = "0.3.2"
+version = "0.3.3"
 description = "LASP SPICE extentions and geospatial data product generation tools."
 authors = [{ name = "Brandon Stone", email = "brandon.h.stone@colorado.edu" }]
 readme = "README.md"

--- a/tests/test_compute/test_compute_geometry.py
+++ b/tests/test_compute/test_compute_geometry.py
@@ -1,0 +1,237 @@
+"""Tests for the geometry data-field framework (Foundation: issues #58/#59/#60/#65/#67).
+
+The pure-math leaves (in ``geometry``) are tested against known values and the
+``GeometryData`` orchestration with fake providers, so the bulk of the suite
+needs no SPICE kernels. ``GeometryIntegrationTestCase`` exercises the real
+provider paths against the committed CLARREO testcase kernels.
+"""
+
+import logging
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from curryer import meta, spicetime, spicierpy, utils
+from curryer.compute import constants, geometry
+
+logger = logging.getLogger(__name__)
+utils.enable_logging(extra_loggers=[__name__])
+
+
+class TestGeometryLeaves:
+    """Pure-math leaf functions in ``geometry`` (no SPICE)."""
+
+    def test_sc_radius_known_values(self):
+        major = constants.WGS84_SEMI_MAJOR_AXIS_KM
+        position = np.array([[major, 0.0, 0.0], [0.0, 3.0, 4.0]])
+        npt.assert_allclose(geometry.sc_radius(position), [major, 5.0])
+
+    def test_sc_radius_single_point(self):
+        radius = geometry.sc_radius(np.array([0.0, 0.0, 7000.0]))
+        assert np.ndim(radius) == 0
+        npt.assert_allclose(radius, 7000.0)
+
+    def test_sc_radius_bad_shape(self):
+        with pytest.raises(ValueError, match="3 values per point"):
+            geometry.sc_radius(np.array([1.0, 2.0]))
+
+    def test_colatitude_degrees(self):
+        npt.assert_allclose(geometry.colatitude(np.array([90.0, 0.0, -90.0])), [0.0, 90.0, 180.0])
+
+    def test_colatitude_radians(self):
+        npt.assert_allclose(geometry.colatitude(np.array([0.0]), degrees=False), [np.pi / 2])
+
+    def test_subobserver_point_equator(self):
+        # A point on the +X equator: lat 0, lon 0, colat 90.
+        position = np.array([constants.WGS84_SEMI_MAJOR_AXIS_KM + 500.0, 0.0, 0.0])
+        lat, lon, colat = geometry.subobserver_point(position)
+        npt.assert_allclose([lat, lon, colat], [0.0, 0.0, 90.0], atol=1e-9)
+
+    def test_subobserver_point_north_pole(self):
+        position = np.array([0.0, 0.0, constants.WGS84_SEMI_MINOR_AXIS_KM + 500.0])
+        lat, lon, colat = geometry.subobserver_point(position)
+        npt.assert_allclose(lat, 90.0, atol=1e-9)
+        npt.assert_allclose(colat, 0.0, atol=1e-9)
+
+    def test_subobserver_point_colat_matches_latitude(self):
+        rng = np.random.default_rng(0)
+        position = rng.uniform(-7000, 7000, size=(5, 3))
+        out = geometry.subobserver_point(position)
+        npt.assert_allclose(out[:, 2], 90.0 - out[:, 0])
+
+    def test_earth_sun_distance_au(self):
+        position = np.array([[constants.KM_PER_ASTRONOMICAL_UNIT, 0.0, 0.0]])
+        npt.assert_allclose(geometry.earth_sun_distance(position), [1.0])
+        npt.assert_allclose(geometry.earth_sun_distance(position, au=False), [constants.KM_PER_ASTRONOMICAL_UNIT])
+
+
+def _fake_providers(call_counter, **values):
+    """Build a patch dict of counting fake providers from ``{key: value}``."""
+
+    def _make(key, value):
+        def _provider(ugps_times, ctx):
+            call_counter[key] = call_counter.get(key, 0) + 1
+            return value
+
+        return _provider
+
+    return {key: _make(key, value) for key, value in values.items()}
+
+
+class TestGeometryOrchestration:
+    """``GeometryData`` field selection, minimal querying, and assembly."""
+
+    UGPS = np.array([1_000_000, 2_000_000])
+
+    def _build(self):
+        # __init__ stores raw names and touches no SPICE; safe without kernels.
+        return geometry.GeometryData("SOME_INSTRUMENT")
+
+    def test_get_geometry_single_field_queries_only_its_provider(self):
+        counter = {}
+        sc_pos = np.array([[7000.0, 0.0, 0.0], [0.0, 7000.0, 0.0]])
+        geo = self._build()
+        with patch.dict(geometry._PROVIDERS, _fake_providers(counter, sc_position=sc_pos)):
+            df = geo.get_geometry(self.UGPS, fields=["sc_radius"])
+
+        assert list(df.columns) == ["scradius"]
+        npt.assert_allclose(df["scradius"].values, [7000.0, 7000.0])
+        assert df.index.name == "ugps"
+        # Only sc_position was queried; sun_position untouched.
+        assert counter == {"sc_position": 1}
+
+    def test_get_geometry_multiple_fields_union_of_providers(self):
+        counter = {}
+        sc_pos = np.array([[7000.0, 0.0, 0.0], [0.0, 7000.0, 0.0]])
+        sun_pos = np.array([[1.5e8, 0.0, 0.0], [1.5e8, 1.0e6, 0.0]])
+        geo = self._build()
+        fakes = _fake_providers(counter, sc_position=sc_pos, sun_position=sun_pos)
+        with patch.dict(geometry._PROVIDERS, fakes):
+            df = geo.get_geometry(self.UGPS, fields=["sc_position", "subsolar"])
+
+        assert list(df.columns) == ["scx", "scy", "scz", "subsollat", "subsollon", "subsolcolat"]
+        npt.assert_allclose(df[["scx", "scy", "scz"]].values, sc_pos)
+        # Each needed provider queried once.
+        assert counter == {"sc_position": 1, "sun_position": 1}
+
+    def test_get_vectors_returns_n3_arrays(self):
+        counter = {}
+        sc_pos = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        geo = self._build()
+        with patch.dict(geometry._PROVIDERS, _fake_providers(counter, sc_position=sc_pos)):
+            vecs = geo.get_vectors(self.UGPS, fields=["sc_position"])
+
+        assert vecs["sc_position"].shape == (2, 3)
+        npt.assert_allclose(vecs["sc_position"], sc_pos)
+
+    def _full_fakes(self, counter):
+        """Fakes for every Foundation provider, sized to UGPS (N=2)."""
+        sc_pos = np.array([[7000.0, 0.0, 0.0], [0.0, 7000.0, 0.0]])
+        sun_pos = np.array([[1.5e8, 0.0, 0.0], [1.5e8, 1.0e6, 0.0]])
+        return _fake_providers(counter, sc_position=sc_pos, sun_position=sun_pos)
+
+    def test_default_fields_are_all_registered(self):
+        counter = {}
+        geo = self._build()
+        with patch.dict(geometry._PROVIDERS, self._full_fakes(counter)):
+            df = geo.get_geometry(self.UGPS)
+
+        for field in geometry.GeometryData.available_fields():
+            for column in geometry._FIELDS[field].columns:
+                assert column in df.columns
+
+    def test_subset_queries_only_needed_providers(self):
+        counter = {}
+        geo = self._build()
+        with patch.dict(geometry._PROVIDERS, self._full_fakes(counter)):
+            geo.get_geometry(self.UGPS, fields=["subsatellite", "earth_sun_distance"])
+        # subsatellite -> sc_position, earth_sun_distance -> sun_position only.
+        assert counter == {"sc_position": 1, "sun_position": 1}
+
+    def test_unknown_field_raises(self):
+        geo = self._build()
+        with pytest.raises(KeyError, match="Unknown geometry field"):
+            geo.get_geometry(self.UGPS, fields=["not_a_field"])
+
+    def test_shared_provider_queried_once(self):
+        # Requesting sc_radius + subsatellite + sc_position must hit sc_position
+        # exactly once (shared provider, not re-queried per field).
+        counter = {}
+        sc_pos = np.array([[7000.0, 0.0, 0.0], [0.0, 7000.0, 0.0]])
+        geo = self._build()
+        with patch.dict(geometry._PROVIDERS, _fake_providers(counter, sc_position=sc_pos)):
+            df = geo.get_geometry(self.UGPS, fields=["sc_radius", "subsatellite", "sc_position"])
+
+        assert counter == {"sc_position": 1}
+        assert "scradius" in df.columns
+        assert "subsatlat" in df.columns
+        assert "scx" in df.columns
+
+    def test_nan_provider_row_propagates(self):
+        # A data gap (NaN provider row) must surface as NaN, not crash, so
+        # downstream consumers can detect it; finite rows stay finite.
+        counter = {}
+        sc_pos = np.array([[7000.0, 0.0, 0.0], [np.nan, np.nan, np.nan]])
+        geo = self._build()
+        with patch.dict(geometry._PROVIDERS, _fake_providers(counter, sc_position=sc_pos)):
+            df = geo.get_geometry(self.UGPS, fields=["sc_radius", "subsatellite"])
+        assert np.isfinite(df.iloc[0]).all()
+        assert df.iloc[1].isna().all()
+
+
+class GeometryIntegrationTestCase(unittest.TestCase):
+    """End-to-end tests exercising the real SPICE provider paths.
+
+    Uses the committed CLARREO testcase kernels (same fixture as the spatial
+    integration tests): instrument ``CPRS_HYSICS`` over 2023-01-01.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        root_dir = Path(__file__).parents[2]
+        cls.generic_dir = root_dir / "data" / "generic"
+        cls.test_dir = root_dir / "tests" / "data" / "clarreo"
+        assert cls.generic_dir.is_dir()
+        assert cls.test_dir.is_dir()
+
+        cls.mkrn = meta.MetaKernel.from_json(
+            cls.test_dir / "cprs_v01.kernels.tm.testcase1.json",
+            relative=True,
+            sds_dir=cls.generic_dir,
+        )
+        cls.instrument = "CPRS_HYSICS"
+        cls.ugps = spicetime.adapt(np.array(["2023-01-01", "2023-01-01T00:01"]), "iso")
+
+    def test_get_geometry_all_fields_real_kernels(self):
+        geo = geometry.GeometryData(self.instrument)
+        with self.mkrn.load():
+            df = geo.get_geometry(self.ugps)
+
+        for field in geometry.GeometryData.available_fields():
+            for column in geometry._FIELDS[field].columns:
+                self.assertIn(column, df.columns)
+
+        # Foundation fields are all position-derived -> gap-free over covered times.
+        self.assertFalse(df.isna().any().any(), msg=f"unexpected NaNs:\n{df.isna().sum()}")
+
+        # Physical sanity ranges.
+        self.assertTrue(df["subsatcolat"].between(0, 180).all())
+        self.assertTrue(df["subsatlon"].between(-180, 180).all())
+        self.assertTrue(df["scradius"].between(6500, 7500).all())  # ISS-class orbit.
+        self.assertTrue(df["earthsundist"].between(0.97, 1.03).all())
+
+    def test_get_vectors_itrf93_matches_direct_query(self):
+        geo = geometry.GeometryData(self.instrument)
+        with self.mkrn.load():
+            vectors = geo.get_vectors(self.ugps, fields=["sc_position"])
+            reference = spicierpy.ext.query_ephemeris(
+                self.ugps, target=self.instrument, observer="EARTH", ref_frame="ITRF93", velocity=False
+            )
+
+        self.assertEqual(vectors["sc_position"].shape, (2, 3))
+        # sc_position is exactly the ITRF93 ephemeris position.
+        npt.assert_allclose(vectors["sc_position"], reference[["x", "y", "z"]].values, rtol=1e-9)

--- a/tests/test_compute/test_compute_geometry.py
+++ b/tests/test_compute/test_compute_geometry.py
@@ -182,6 +182,23 @@ class TestGeometryOrchestration:
         assert np.isfinite(df.iloc[0]).all()
         assert df.iloc[1].isna().all()
 
+    @pytest.mark.parametrize("field", list(geometry._FIELDS))
+    def test_nan_propagates_per_field(self, field):
+        # Fill contract: every field must NaN exactly the rows its inputs are
+        # missing and stay finite elsewhere, whichever provider feeds it. Both
+        # providers carry a NaN second row so the test is provider-agnostic.
+        counter = {}
+        sc_pos = np.array([[7000.0, 0.0, 0.0], [np.nan, np.nan, np.nan]])
+        sun_pos = np.array([[1.5e8, 0.0, 0.0], [np.nan, np.nan, np.nan]])
+        geo = self._build()
+        fakes = _fake_providers(counter, sc_position=sc_pos, sun_position=sun_pos)
+        with patch.dict(geometry._PROVIDERS, fakes):
+            df = geo.get_geometry(self.UGPS, fields=[field])
+
+        columns = list(geometry._FIELDS[field].columns)
+        assert np.isfinite(df.iloc[0][columns]).all()
+        assert df.iloc[1][columns].isna().all()
+
 
 class GeometryIntegrationTestCase(unittest.TestCase):
     """End-to-end tests exercising the real SPICE provider paths.

--- a/tests/test_compute/test_compute_geometry.py
+++ b/tests/test_compute/test_compute_geometry.py
@@ -98,8 +98,8 @@ class TestGeometryOrchestration:
         with patch.dict(geometry._PROVIDERS, _fake_providers(counter, sc_position=sc_pos)):
             df = geo.get_geometry(self.UGPS, fields=["sc_radius"])
 
-        assert list(df.columns) == ["scradius"]
-        npt.assert_allclose(df["scradius"].values, [7000.0, 7000.0])
+        assert list(df.columns) == ["spacecraft_radius"]
+        npt.assert_allclose(df["spacecraft_radius"].values, [7000.0, 7000.0])
         assert df.index.name == "ugps"
         # Only sc_position was queried; sun_position untouched.
         assert counter == {"sc_position": 1}
@@ -113,8 +113,17 @@ class TestGeometryOrchestration:
         with patch.dict(geometry._PROVIDERS, fakes):
             df = geo.get_geometry(self.UGPS, fields=["sc_position", "subsolar"])
 
-        assert list(df.columns) == ["scx", "scy", "scz", "subsollat", "subsollon", "subsolcolat"]
-        npt.assert_allclose(df[["scx", "scy", "scz"]].values, sc_pos)
+        assert list(df.columns) == [
+            "spacecraft_position_x",
+            "spacecraft_position_y",
+            "spacecraft_position_z",
+            "subsolar_latitude",
+            "subsolar_longitude",
+            "subsolar_colatitude",
+        ]
+        npt.assert_allclose(
+            df[["spacecraft_position_x", "spacecraft_position_y", "spacecraft_position_z"]].values, sc_pos
+        )
         # Each needed provider queried once.
         assert counter == {"sc_position": 1, "sun_position": 1}
 
@@ -167,9 +176,9 @@ class TestGeometryOrchestration:
             df = geo.get_geometry(self.UGPS, fields=["sc_radius", "subsatellite", "sc_position"])
 
         assert counter == {"sc_position": 1}
-        assert "scradius" in df.columns
-        assert "subsatlat" in df.columns
-        assert "scx" in df.columns
+        assert "spacecraft_radius" in df.columns
+        assert "subsatellite_latitude" in df.columns
+        assert "spacecraft_position_x" in df.columns
 
     def test_nan_provider_row_propagates(self):
         # A data gap (NaN provider row) must surface as NaN, not crash, so
@@ -236,10 +245,10 @@ class GeometryIntegrationTestCase(unittest.TestCase):
         self.assertFalse(df.isna().any().any(), msg=f"unexpected NaNs:\n{df.isna().sum()}")
 
         # Physical sanity ranges.
-        self.assertTrue(df["subsatcolat"].between(0, 180).all())
-        self.assertTrue(df["subsatlon"].between(-180, 180).all())
-        self.assertTrue(df["scradius"].between(6500, 7500).all())  # ISS-class orbit.
-        self.assertTrue(df["earthsundist"].between(0.97, 1.03).all())
+        self.assertTrue(df["subsatellite_colatitude"].between(0, 180).all())
+        self.assertTrue(df["subsatellite_longitude"].between(-180, 180).all())
+        self.assertTrue(df["spacecraft_radius"].between(6500, 7500).all())  # ISS-class orbit.
+        self.assertTrue(df["earth_sun_distance"].between(0.97, 1.03).all())
 
     def test_get_vectors_itrf93_matches_direct_query(self):
         geo = geometry.GeometryData(self.instrument)

--- a/tests/test_compute/test_compute_geometry.py
+++ b/tests/test_compute/test_compute_geometry.py
@@ -149,15 +149,19 @@ class TestGeometryOrchestration:
         sun_pos = np.array([[1.5e8, 0.0, 0.0], [1.5e8, 1.0e6, 0.0]])
         return _fake_providers(counter, sc_position=sc_pos, sun_position=sun_pos)
 
-    def test_default_fields_are_all_registered(self):
+    def test_default_fields_are_ephemeris_only(self):
         counter = {}
         geo = self._build()
         with patch.dict(geometry._PROVIDERS, self._full_fakes(counter)):
             df = geo.get_geometry(self.UGPS)
 
-        for field in geometry.GeometryData.available_fields():
-            for column in geometry._FIELDS[field].columns:
-                assert column in df.columns
+        # Default is exactly the ephemeris-only field set...
+        expected = [col for field in geometry._DEFAULT_FIELDS for col in geometry._FIELDS[field].columns]
+        assert list(df.columns) == expected
+        # ...and that set needs only ephemeris providers (no attitude/FOV), so the
+        # default never implicitly requires attitude kernels as fields are added.
+        for field in geometry._DEFAULT_FIELDS:
+            assert geometry._FIELDS[field].providers <= geometry._EPHEMERIS_PROVIDERS
 
     def test_subset_queries_only_needed_providers(self):
         counter = {}
@@ -212,6 +216,26 @@ class TestGeometryOrchestration:
             df = geo.get_geometry(self.UGPS, fields=["sc_radius", "subsatellite"])
         assert np.isfinite(df.iloc[0]).all()
         assert df.iloc[1].isna().all()
+
+    def test_all_nan_provider_warns_only_when_fully_empty(self, caplog):
+        # An all-NaN provider is the documented missing-kernel signal and must
+        # warn; a partial gap (some finite rows) is normal coverage and must not.
+        geo = self._build()
+
+        partial = np.array([[7000.0, 0.0, 0.0], [np.nan, np.nan, np.nan]])
+        with patch.dict(geometry._PROVIDERS, _fake_providers({}, sc_position=partial)):
+            with caplog.at_level(logging.WARNING, logger="curryer.compute.geometry"):
+                geo.get_geometry(self.UGPS, fields=["sc_radius"])
+        assert not [r for r in caplog.records if "all-NaN" in r.getMessage()]
+
+        caplog.clear()
+        empty = np.full((2, 3), np.nan)
+        with patch.dict(geometry._PROVIDERS, _fake_providers({}, sc_position=empty)):
+            with caplog.at_level(logging.WARNING, logger="curryer.compute.geometry"):
+                geo.get_geometry(self.UGPS, fields=["sc_radius"])
+        warnings = [r.getMessage() for r in caplog.records if "all-NaN" in r.getMessage()]
+        assert warnings
+        assert "sc_position" in warnings[0]
 
     @pytest.mark.parametrize("field", list(geometry._FIELDS))
     def test_nan_propagates_per_field(self, field):

--- a/tests/test_compute/test_compute_geometry.py
+++ b/tests/test_compute/test_compute_geometry.py
@@ -1,4 +1,4 @@
-"""Tests for the geometry data-field framework (Foundation: issues #58/#59/#60/#65/#67).
+"""Tests for the geometry data-field framework (Foundation fields).
 
 The pure-math leaves (in ``geometry``) are tested against known values and the
 ``GeometryData`` orchestration with fake providers, so the bulk of the suite

--- a/tests/test_compute/test_compute_geometry.py
+++ b/tests/test_compute/test_compute_geometry.py
@@ -1,4 +1,4 @@
-"""Tests for the geometry data-field framework (Foundation fields).
+"""Tests for the geometry data-field framework.
 
 The pure-math leaves (in ``geometry``) are tested against known values and the
 ``GeometryData`` orchestration with fake providers, so the bulk of the suite
@@ -129,7 +129,7 @@ class TestGeometryOrchestration:
         npt.assert_allclose(vecs["sc_position"], sc_pos)
 
     def _full_fakes(self, counter):
-        """Fakes for every Foundation provider, sized to UGPS (N=2)."""
+        """Fakes for every registered provider, sized to UGPS (N=2)."""
         sc_pos = np.array([[7000.0, 0.0, 0.0], [0.0, 7000.0, 0.0]])
         sun_pos = np.array([[1.5e8, 0.0, 0.0], [1.5e8, 1.0e6, 0.0]])
         return _fake_providers(counter, sc_position=sc_pos, sun_position=sun_pos)
@@ -173,7 +173,7 @@ class TestGeometryOrchestration:
 
     def test_nan_provider_row_propagates(self):
         # A data gap (NaN provider row) must surface as NaN, not crash, so
-        # downstream consumers can detect it; finite rows stay finite.
+        # callers can detect it; finite rows stay finite.
         counter = {}
         sc_pos = np.array([[7000.0, 0.0, 0.0], [np.nan, np.nan, np.nan]])
         geo = self._build()
@@ -232,7 +232,7 @@ class GeometryIntegrationTestCase(unittest.TestCase):
             for column in geometry._FIELDS[field].columns:
                 self.assertIn(column, df.columns)
 
-        # Foundation fields are all position-derived -> gap-free over covered times.
+        # These fields are all position-derived -> gap-free over covered times.
         self.assertFalse(df.isna().any().any(), msg=f"unexpected NaNs:\n{df.isna().sum()}")
 
         # Physical sanity ranges.

--- a/tests/test_compute/test_compute_geometry.py
+++ b/tests/test_compute/test_compute_geometry.py
@@ -68,6 +68,12 @@ class TestGeometryLeaves:
         npt.assert_allclose(geometry.earth_sun_distance(position), [1.0])
         npt.assert_allclose(geometry.earth_sun_distance(position, au=False), [constants.KM_PER_ASTRONOMICAL_UNIT])
 
+    def test_satellite_altitude_known_values(self):
+        # 500 km above the +X equator and above the north pole.
+        equator = np.array([constants.WGS84_SEMI_MAJOR_AXIS_KM + 500.0, 0.0, 0.0])
+        pole = np.array([0.0, 0.0, constants.WGS84_SEMI_MINOR_AXIS_KM + 500.0])
+        npt.assert_allclose(geometry.satellite_altitude(np.stack([equator, pole])), [500.0, 500.0], atol=1e-6)
+
 
 def _fake_providers(call_counter, **values):
     """Build a patch dict of counting fake providers from ``{key: value}``."""
@@ -160,6 +166,22 @@ class TestGeometryOrchestration:
             geo.get_geometry(self.UGPS, fields=["subsatellite", "earth_sun_distance"])
         # subsatellite -> sc_position, earth_sun_distance -> sun_position only.
         assert counter == {"sc_position": 1, "sun_position": 1}
+
+    def test_sc_altitude_field(self):
+        counter = {}
+        # 500 km and 800 km above the +X equator.
+        sc_pos = np.array(
+            [
+                [constants.WGS84_SEMI_MAJOR_AXIS_KM + 500.0, 0.0, 0.0],
+                [constants.WGS84_SEMI_MAJOR_AXIS_KM + 800.0, 0.0, 0.0],
+            ]
+        )
+        geo = self._build()
+        with patch.dict(geometry._PROVIDERS, _fake_providers(counter, sc_position=sc_pos)):
+            df = geo.get_geometry(self.UGPS, fields=["sc_altitude"])
+        assert list(df.columns) == ["spacecraft_altitude"]
+        npt.assert_allclose(df["spacecraft_altitude"].values, [500.0, 800.0], atol=1e-6)
+        assert counter == {"sc_position": 1}
 
     def test_unknown_field_raises(self):
         geo = self._build()


### PR DESCRIPTION
## Context

The Libera L1B products (and other Level-1 missions) define ~30 geometry/geolocation
ancillary fields — subsatellite/subsolar point, colatitude, satellite radius,
Earth-Sun distance, viewing/solar angles, etc. — that are today filled with `-999`.
With no shared implementation, downstream consumers (libera_rad, libera_cam) have
begun re-deriving these fields independently, and some reimplementations have
diverged (e.g. a subsatellite point computed by intersecting a body axis with the
ellipsoid — attitude-dependent and off by kilometers, versus the correct
position-derived definition).

This PR puts the **generic, mission-agnostic** field math where it belongs — in
curryer — so every mission consumes one correct, tested implementation instead of
hand-rolling its own. It is the **Foundation (PR 1)** of a short series: it lands
the easy single-query, position-derived fields end-to-end and establishes the
registry pattern, frame contract, and fill contract that the later PRs build on.

## Issues addressed

- Closes #58 — Subsatellite point
- Closes #59 — Subsolar point
- Closes #65 — Radius of satellite
- Closes #67 — Earth-Sun distance
- Addresses #60 — Colatitude (the leaf lands here; the surface-footprint
  `surface_colatitude` *field* arrives in the next PR)

## New geometry module and selective-compute framework

* Added the new `geometry.py` module, which implements:
  - Pure, vectorized math-only leaf functions for geometric computations such as
    `sc_radius`, `colatitude`, `subobserver_point`, and `earth_sun_distance`.
    These are importable and composable on their own — the building blocks a
    mission uses for custom fields.
  - A registry-based system mapping each output field to its minimal set of
    required SPICE-derived providers, ensuring each provider is queried only once
    per request (no redundant SPICE passes when several fields share an input).
  - The `GeometryData` class, which offers APIs to retrieve geometric data as
    either a `pandas.DataFrame` or as typed numpy arrays, with robust handling of
    SPICE coverage gaps (NaN propagation, documented as a per-field fill contract
    so downstream maps cleanly onto the product `_FillValue`).
  - Mission genericity: the observing body is the only mission input; no
    spacecraft/instrument names are hardcoded. All ECEF fields share one
    configured Earth-fixed frame (ITRF93 by default).
* Registered the new `geometry` module in the `curryer.compute` package's
  `__init__.py`, updating `__all__` to include it.

## Testing and validation

* Added a comprehensive test suite in `tests/test_compute/test_compute_geometry.py`
  that covers:
  - Unit tests for pure math leaf functions, ensuring correctness without SPICE
    dependencies.
  - Orchestration tests for the `GeometryData` class using fake providers to
    verify minimal querying, field selection, and per-field NaN
  - End-to-end integration tests using real SPICE kernels to validate the full
    provider paths and physical sanity of computed values.

## What's next (follow-on PRs)

This Foundation deliberately scopes to the fields with no open
on top:

- **PR 2** — composed-but-ready fields: instrument boresight and surface-footprint
  colatitude (adds the attitude/boresight/surface providers), p
  `frame_euler` primitive that lets downstream stop open-coding scalar
  `pxform`→`m2eul` loops.
- **Later** — convention-gated fields (along/cross-track, relative azimuth,
  cone/clock, gimbal az/el) and the J2000/ECEF frame-specific s
  fields, once their conventions and kernels are confirmed.