### PR TITLE
Add standalone frame_euler function for Euler angle conversion between frames

### DIFF
--- a/curryer/compute/spatial.py
+++ b/curryer/compute/spatial.py
@@ -323,7 +323,85 @@ def instrument_pointing_state(
     return pnt_data, sc_data, qf_data
 
 
-def frame_euler(
+def frame_to_frame_rotation(
+    from_frame: int | str | spicierpy.obj.Frame,
+    to_frame: int | str | spicierpy.obj.Frame,
+    ugps_times: np.ndarray,
+    allow_nans=False,
+) -> np.ndarray:
+    """Rotation matrices taking one reference frame into another over time.
+
+    The per-sample ``pxform(from_frame, to_frame, t)`` rotation stacked over the
+    requested times -- the shared SPICE query behind :func:`frame_to_frame_euler` and
+    :func:`frame_to_frame_quaternion`. Call it directly when the matrix itself is wanted
+    (e.g. to rotate vectors) or to derive several representations from a single query.
+
+    Note
+    ----
+    ``pxform`` has no vectorized SpiceyPy override, so this loops per sample -- an
+    inherent scalar cost, not a missing optimization. For dense time grids, compute on a
+    coarse CK-cadence grid (see ``AbstractMissionData.get_times``) and interpolate rather
+    than calling this at full rate.
+
+    Parameters
+    ----------
+    from_frame, to_frame : str or int or spicierpy.obj.Frame
+        Source and destination reference frames; the returned matrices rotate
+        ``from_frame`` into ``to_frame``. Relevant CK/FK kernels must be loaded.
+    ugps_times : array_like of int
+        One or more times in GPS microseconds.
+    allow_nans : bool, optional
+        Convert recoverable SPICE failures (e.g. attitude gaps) into all-NaN matrices.
+        Default False raises instead.
+
+    Returns
+    -------
+    numpy.ndarray
+        Rotation matrices, shape (N, 3, 3). Samples without attitude coverage are
+        all-NaN when ``allow_nans``.
+
+    """
+    from_name = spicierpy.obj.Frame(from_frame).name
+    to_name = spicierpy.obj.Frame(to_frame).name
+    ugps_times = np.atleast_1d(np.asarray(ugps_times))
+    et_times = spicetime.adapt(ugps_times, to="et")
+
+    @spicierpy.ext.spice_error_to_val(err_value=np.full((3, 3), np.nan), disable=not allow_nans)
+    def _rotation(sample_et):
+        return spicierpy.pxform(from_name, to_name, sample_et)
+
+    return np.array([_rotation(sample_et)[0] for sample_et in et_times])
+
+
+def _rotation_rows(matrices, convert, n_columns):
+    """Apply a per-matrix ``convert`` to each rotation, passing NaN matrices through.
+
+    Attitude gaps arrive from :func:`frame_to_frame_rotation` as all-NaN matrices; those
+    rows stay NaN (``convert`` -- a SPICE routine -- is never called on invalid input).
+
+    Parameters
+    ----------
+    matrices : numpy.ndarray
+        Rotation matrices, shape (N, 3, 3).
+    convert : callable
+        Maps one (3, 3) matrix to a length-``n_columns`` representation.
+    n_columns : int
+        Width of the converted output.
+
+    Returns
+    -------
+    numpy.ndarray
+        Converted rows, shape (N, n_columns); all-NaN for NaN input matrices.
+
+    """
+    rows = np.full((len(matrices), n_columns), np.nan)
+    for ith, matrix in enumerate(matrices):
+        if not np.isnan(matrix).any():
+            rows[ith] = convert(matrix)
+    return rows
+
+
+def frame_to_frame_euler(
     from_frame: int | str | spicierpy.obj.Frame,
     to_frame: int | str | spicierpy.obj.Frame,
     ugps_times: np.ndarray,
@@ -333,19 +411,12 @@ def frame_euler(
 ) -> pd.DataFrame:
     """Euler angles rotating one reference frame into another over time.
 
-    Factors the frame-to-frame rotation ``pxform(from_frame, to_frame, t)`` into
-    three Euler angles about the axes in ``sequence`` (via ``m2eul``). Generic over
-    the frame pair: missions parameterize it with their own frames, so the
-    instrument-specific gimbal/pointing field stays downstream while the conversion
-    lives here. This is the standalone form of the per-sample Euler extraction that
+    Factors the frame-to-frame rotation (:func:`frame_to_frame_rotation`) into three
+    Euler angles about the axes in ``sequence`` (via ``m2eul``). Generic over the frame
+    pair: missions parameterize it with their own frames, so the instrument-specific
+    gimbal/pointing field stays downstream while the conversion lives here. This is the
+    standalone form of the per-sample Euler extraction that
     :func:`instrument_pointing_state` computes internally.
-
-    Note
-    ----
-    ``pxform`` has no vectorized SpiceyPy override, so this loops per sample -- an
-    inherent scalar cost, not a missing optimization. For dense time grids, compute
-    on a coarse CK-cadence grid (see ``AbstractMissionData.get_times``) and
-    interpolate rather than calling this at full rate.
 
     Parameters
     ----------
@@ -376,21 +447,58 @@ def frame_euler(
     if sequence[0] == sequence[1] or sequence[1] == sequence[2]:
         raise ValueError(f"`sequence` may not repeat adjacent axes (m2eul restriction), got: {sequence}")
 
-    from_name = spicierpy.obj.Frame(from_frame).name
-    to_name = spicierpy.obj.Frame(to_frame).name
     ugps_times = np.atleast_1d(np.asarray(ugps_times))
-    et_times = spicetime.adapt(ugps_times, to="et")
-
-    @spicierpy.ext.spice_error_to_val(err_value=np.full(3, np.nan), disable=not allow_nans)
-    def _euler(sample_et):
-        return spicierpy.m2eul(spicierpy.pxform(from_name, to_name, sample_et), *sequence)
-
-    angles = np.array([_euler(sample_et)[0] for sample_et in et_times])
+    matrices = frame_to_frame_rotation(from_frame, to_frame, ugps_times, allow_nans=allow_nans)
+    angles = _rotation_rows(matrices, lambda matrix: spicierpy.m2eul(matrix, *sequence), 3)
     if degrees:
         angles = np.rad2deg(angles)
 
+    from_name = spicierpy.obj.Frame(from_frame).name
+    to_name = spicierpy.obj.Frame(to_frame).name
     data = pd.DataFrame(angles, columns=["euler1", "euler2", "euler3"], index=pd.Index(ugps_times, name="ugps"))
     data.columns.name = f"Euler[{from_name}->{to_name}]"
+    return data
+
+
+def frame_to_frame_quaternion(
+    from_frame: int | str | spicierpy.obj.Frame,
+    to_frame: int | str | spicierpy.obj.Frame,
+    ugps_times: np.ndarray,
+    allow_nans=False,
+) -> pd.DataFrame:
+    """Quaternion rotating one reference frame into another over time.
+
+    Converts the frame-to-frame rotation (:func:`frame_to_frame_rotation`) to a SPICE
+    quaternion (via ``m2q``): scalar-first ``[q0, q1, q2, q3]`` with ``q0 = cos(theta/2)``.
+    The unit-norm, singularity-free sibling of :func:`frame_to_frame_euler` for the same
+    rotation.
+
+    Parameters
+    ----------
+    from_frame, to_frame : str or int or spicierpy.obj.Frame
+        Source and destination reference frames; the returned quaternion rotates
+        ``from_frame`` into ``to_frame``. Relevant CK/FK kernels must be loaded.
+    ugps_times : array_like of int
+        One or more times in GPS microseconds.
+    allow_nans : bool, optional
+        Convert recoverable SPICE failures (e.g. attitude gaps) into NaN rows.
+        Default False raises instead.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Columns ``q0, q1, q2, q3`` (SPICE scalar-first convention), indexed by ``ugps``.
+        Rows without attitude coverage are NaN when ``allow_nans``.
+
+    """
+    ugps_times = np.atleast_1d(np.asarray(ugps_times))
+    matrices = frame_to_frame_rotation(from_frame, to_frame, ugps_times, allow_nans=allow_nans)
+    quaternions = _rotation_rows(matrices, spicierpy.m2q, 4)
+
+    from_name = spicierpy.obj.Frame(from_frame).name
+    to_name = spicierpy.obj.Frame(to_frame).name
+    data = pd.DataFrame(quaternions, columns=["q0", "q1", "q2", "q3"], index=pd.Index(ugps_times, name="ugps"))
+    data.columns.name = f"Quaternion[{from_name}->{to_name}]"
     return data
 
 

--- a/curryer/compute/spatial.py
+++ b/curryer/compute/spatial.py
@@ -323,6 +323,77 @@ def instrument_pointing_state(
     return pnt_data, sc_data, qf_data
 
 
+def frame_euler(
+    from_frame: int | str | spicierpy.obj.Frame,
+    to_frame: int | str | spicierpy.obj.Frame,
+    ugps_times: np.ndarray,
+    sequence=(1, 2, 3),
+    degrees=True,
+    allow_nans=False,
+) -> pd.DataFrame:
+    """Euler angles rotating one reference frame into another over time.
+
+    Factors the frame-to-frame rotation ``pxform(from_frame, to_frame, t)`` into
+    three Euler angles about the axes in ``sequence`` (via ``m2eul``). Generic over
+    the frame pair: missions parameterize it with their own frames, so the
+    instrument-specific gimbal/pointing field stays downstream while the conversion
+    lives here. This is the standalone form of the per-sample Euler extraction that
+    :func:`instrument_pointing_state` computes internally.
+
+    Note
+    ----
+    ``pxform`` has no vectorized SpiceyPy override, so this loops per sample -- an
+    inherent scalar cost, not a missing optimization. For dense time grids, compute
+    on a coarse CK-cadence grid (see ``AbstractMissionData.get_times``) and
+    interpolate rather than calling this at full rate.
+
+    Parameters
+    ----------
+    from_frame, to_frame : str or int or spicierpy.obj.Frame
+        Source and destination reference frames; the returned angles rotate
+        ``from_frame`` into ``to_frame``. Relevant CK/FK kernels must be loaded.
+    ugps_times : array_like of int
+        One or more times in GPS microseconds.
+    sequence : tuple of int, optional
+        The three rotation axes (1=X, 2=Y, 3=Z) to factor into, in ``m2eul`` order.
+        Adjacent axes must differ. Default ``(1, 2, 3)``.
+    degrees : bool, optional
+        If True (default), angles are in degrees, otherwise radians.
+    allow_nans : bool, optional
+        Convert recoverable SPICE failures (e.g. attitude gaps) into NaN rows.
+        Default False raises instead.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Columns ``euler1, euler2, euler3`` -- the angle about ``sequence[0]``,
+        ``sequence[1]``, ``sequence[2]`` respectively -- indexed by ``ugps``. Rows
+        without attitude coverage are NaN when ``allow_nans``.
+
+    """
+    if len(sequence) != 3 or any(axis not in (1, 2, 3) for axis in sequence):
+        raise ValueError(f"`sequence` must be three axes from (1, 2, 3), got: {sequence}")
+    if sequence[0] == sequence[1] or sequence[1] == sequence[2]:
+        raise ValueError(f"`sequence` may not repeat adjacent axes (m2eul restriction), got: {sequence}")
+
+    from_name = spicierpy.obj.Frame(from_frame).name
+    to_name = spicierpy.obj.Frame(to_frame).name
+    ugps_times = np.atleast_1d(np.asarray(ugps_times))
+    et_times = spicetime.adapt(ugps_times, to="et")
+
+    @spicierpy.ext.spice_error_to_val(err_value=np.full(3, np.nan), disable=not allow_nans)
+    def _euler(sample_et):
+        return spicierpy.m2eul(spicierpy.pxform(from_name, to_name, sample_et), *sequence)
+
+    angles = np.array([_euler(sample_et)[0] for sample_et in et_times])
+    if degrees:
+        angles = np.rad2deg(angles)
+
+    data = pd.DataFrame(angles, columns=["euler1", "euler2", "euler3"], index=pd.Index(ugps_times, name="ugps"))
+    data.columns.name = f"Euler[{from_name}->{to_name}]"
+    return data
+
+
 def compute_ellipsoid_intersection(
     ugps_times: np.ndarray,
     instrument: int | str | spicierpy.obj.Body,

--- a/tests/test_compute/test_compute_spatial.py
+++ b/tests/test_compute/test_compute_spatial.py
@@ -78,16 +78,16 @@ class SpatialTestCase(unittest.TestCase):
                 allow_nans=False,
             )
 
-    def test_unit_frame_euler_invalid_sequence_raises(self):
+    def test_unit_frame_to_frame_euler_invalid_sequence_raises(self):
         ugps = np.array([1_000_000])
         with self.assertRaises(ValueError):
-            spatial.frame_euler("A", "B", ugps, sequence=(1, 2))  # not three axes
+            spatial.frame_to_frame_euler("A", "B", ugps, sequence=(1, 2))  # not three axes
         with self.assertRaises(ValueError):
-            spatial.frame_euler("A", "B", ugps, sequence=(1, 4, 2))  # axis out of range
+            spatial.frame_to_frame_euler("A", "B", ugps, sequence=(1, 4, 2))  # axis out of range
         with self.assertRaises(ValueError):
-            spatial.frame_euler("A", "B", ugps, sequence=(1, 1, 2))  # adjacent repeat
+            spatial.frame_to_frame_euler("A", "B", ugps, sequence=(1, 1, 2))  # adjacent repeat
 
-    def test_unit_frame_euler_degrees_and_columns(self):
+    def test_unit_frame_to_frame_euler_degrees_and_columns(self):
         # Angles are m2eul(pxform(...)) per sample; degrees converts from radians,
         # columns/index follow the sequence order and ugps.
         ugps = np.array([1_000_000, 2_000_000])
@@ -97,14 +97,14 @@ class SpatialTestCase(unittest.TestCase):
             patch.object(spatial.spicierpy, "pxform", return_value=np.eye(3)),
             patch.object(spatial.spicierpy, "m2eul", side_effect=[(0.0, np.pi / 2, np.pi), (np.pi, 0.0, np.pi / 4)]),
         ):
-            df = spatial.frame_euler("INST_FRAME", "ITRF93", ugps)
+            df = spatial.frame_to_frame_euler("INST_FRAME", "ITRF93", ugps)
 
         assert list(df.columns) == ["euler1", "euler2", "euler3"]
         assert df.index.name == "ugps"
         npt.assert_allclose(df.iloc[0].values, [0.0, 90.0, 180.0])
         npt.assert_allclose(df.iloc[1].values, [180.0, 0.0, 45.0])
 
-    def test_unit_frame_euler_radians_passthrough(self):
+    def test_unit_frame_to_frame_euler_radians_passthrough(self):
         ugps = np.array([1_000_000])
         with (
             patch.object(spatial.spicierpy.obj, "Frame"),
@@ -112,10 +112,10 @@ class SpatialTestCase(unittest.TestCase):
             patch.object(spatial.spicierpy, "pxform", return_value=np.eye(3)),
             patch.object(spatial.spicierpy, "m2eul", return_value=(0.1, 0.2, 0.3)),
         ):
-            df = spatial.frame_euler("A", "B", ugps, degrees=False)
+            df = spatial.frame_to_frame_euler("A", "B", ugps, degrees=False)
         npt.assert_allclose(df.iloc[0].values, [0.1, 0.2, 0.3])
 
-    def test_unit_frame_euler_nan_fills_attitude_gap(self):
+    def test_unit_frame_to_frame_euler_nan_fills_attitude_gap(self):
         # A SPICE attitude gap NaN-fills under allow_nans, and raises without it.
         ugps = np.array([1_000_000, 2_000_000])
         gap = spicierpy.utils.exceptions.SpiceyError("SPICE(NOFRAMECONNECT)")
@@ -125,20 +125,20 @@ class SpatialTestCase(unittest.TestCase):
             patch.object(spatial.spicierpy, "pxform", side_effect=gap),
             patch.object(spatial.spicierpy, "m2eul"),
         ):
-            df = spatial.frame_euler("A", "B", ugps, allow_nans=True)
+            df = spatial.frame_to_frame_euler("A", "B", ugps, allow_nans=True)
             assert df.shape == (2, 3)
             assert np.isnan(df.values).all()
 
             with self.assertRaises(spicierpy.utils.exceptions.SpiceyError):
-                spatial.frame_euler("A", "B", ugps, allow_nans=False)
+                spatial.frame_to_frame_euler("A", "B", ugps, allow_nans=False)
 
     @pytest.mark.extra
-    def test_frame_euler_matches_pointing_state(self):
-        # frame_euler is the standalone form of the Euler extraction inside
+    def test_frame_to_frame_euler_matches_pointing_state(self):
+        # frame_to_frame_euler is the standalone form of the Euler extraction inside
         # instrument_pointing_state; over real kernels they must agree exactly.
         ugps = spicetime.adapt(np.array(["2023-01-01", "2023-01-01T00:01"]), "iso")
         with self.mkrn.load():
-            euler = spatial.frame_euler("CPRS_HYSICS_COORD", "ITRF93", ugps)
+            euler = spatial.frame_to_frame_euler("CPRS_HYSICS_COORD", "ITRF93", ugps)
             _, sc_data, _ = spatial.instrument_pointing_state(
                 ugps, "CPRS_HYSICS", pointing_frame="ITRF93", allow_nans=True
             )
@@ -147,15 +147,81 @@ class SpatialTestCase(unittest.TestCase):
         )
 
     @pytest.mark.extra
-    def test_frame_euler_reconstructs_rotation(self):
+    def test_frame_to_frame_euler_reconstructs_rotation(self):
         # Independent check: the returned angles rebuild the frame rotation via eul2m.
         ugps = spicetime.adapt(np.array(["2023-01-01"]), "iso")
         with self.mkrn.load():
-            euler = spatial.frame_euler("CPRS_HYSICS_COORD", "ITRF93", ugps, degrees=False)
+            euler = spatial.frame_to_frame_euler("CPRS_HYSICS_COORD", "ITRF93", ugps, degrees=False)
             et = spicetime.adapt(ugps, to="et")[0]
             expected_rot = spicierpy.pxform("CPRS_HYSICS_COORD", "ITRF93", et)
             e1, e2, e3 = euler.iloc[0].values
             rebuilt = spicierpy.eul2m(e1, e2, e3, 1, 2, 3)
+        npt.assert_allclose(rebuilt, expected_rot, atol=1e-9)
+
+    def test_unit_frame_to_frame_rotation_shape_and_values(self):
+        # The core stacks pxform per sample into (N, 3, 3).
+        ugps = np.array([1_000_000, 2_000_000])
+        with (
+            patch.object(spatial.spicierpy.obj, "Frame"),
+            patch.object(spatial.spicetime, "adapt", return_value=np.array([10.0, 20.0])),
+            patch.object(spatial.spicierpy, "pxform", return_value=np.eye(3)),
+        ):
+            matrices = spatial.frame_to_frame_rotation("A", "B", ugps)
+        assert matrices.shape == (2, 3, 3)
+        npt.assert_allclose(matrices[0], np.eye(3))
+        npt.assert_allclose(matrices[1], np.eye(3))
+
+    def test_unit_frame_to_frame_quaternion_columns(self):
+        # Quaternion columns are SPICE scalar-first q0..q3 over m2q(rotation).
+        ugps = np.array([1_000_000, 2_000_000])
+        with (
+            patch.object(spatial.spicierpy.obj, "Frame"),
+            patch.object(spatial.spicetime, "adapt", return_value=np.array([10.0, 20.0])),
+            patch.object(spatial.spicierpy, "pxform", return_value=np.eye(3)),
+            patch.object(spatial.spicierpy, "m2q", side_effect=[(1.0, 0.0, 0.0, 0.0), (0.0, 1.0, 0.0, 0.0)]),
+        ):
+            df = spatial.frame_to_frame_quaternion("A", "B", ugps)
+        assert list(df.columns) == ["q0", "q1", "q2", "q3"]
+        assert df.index.name == "ugps"
+        npt.assert_allclose(df.iloc[0].values, [1.0, 0.0, 0.0, 0.0])
+        npt.assert_allclose(df.iloc[1].values, [0.0, 1.0, 0.0, 0.0])
+
+    def test_unit_frame_to_frame_quaternion_nan_fills_attitude_gap(self):
+        # A SPICE attitude gap NaN-fills under allow_nans, and raises without it.
+        ugps = np.array([1_000_000, 2_000_000])
+        gap = spicierpy.utils.exceptions.SpiceyError("SPICE(NOFRAMECONNECT)")
+        with (
+            patch.object(spatial.spicierpy.obj, "Frame"),
+            patch.object(spatial.spicetime, "adapt", return_value=np.array([10.0, 20.0])),
+            patch.object(spatial.spicierpy, "pxform", side_effect=gap),
+            patch.object(spatial.spicierpy, "m2q"),
+        ):
+            df = spatial.frame_to_frame_quaternion("A", "B", ugps, allow_nans=True)
+            assert df.shape == (2, 4)
+            assert np.isnan(df.values).all()
+
+            with self.assertRaises(spicierpy.utils.exceptions.SpiceyError):
+                spatial.frame_to_frame_quaternion("A", "B", ugps, allow_nans=False)
+
+    @pytest.mark.extra
+    def test_frame_to_frame_rotation_matches_pxform(self):
+        # The core stacks the same matrices SPICE's pxform returns per sample.
+        ugps = spicetime.adapt(np.array(["2023-01-01"]), "iso")
+        with self.mkrn.load():
+            matrices = spatial.frame_to_frame_rotation("CPRS_HYSICS_COORD", "ITRF93", ugps)
+            et = spicetime.adapt(ugps, to="et")[0]
+            expected_rot = spicierpy.pxform("CPRS_HYSICS_COORD", "ITRF93", et)
+        npt.assert_allclose(matrices[0], expected_rot, atol=1e-12)
+
+    @pytest.mark.extra
+    def test_frame_to_frame_quaternion_reconstructs_rotation(self):
+        # The returned quaternion rebuilds the frame rotation via q2m.
+        ugps = spicetime.adapt(np.array(["2023-01-01"]), "iso")
+        with self.mkrn.load():
+            quat = spatial.frame_to_frame_quaternion("CPRS_HYSICS_COORD", "ITRF93", ugps)
+            et = spicetime.adapt(ugps, to="et")[0]
+            expected_rot = spicierpy.pxform("CPRS_HYSICS_COORD", "ITRF93", et)
+            rebuilt = spicierpy.q2m(quat.iloc[0].values)
         npt.assert_allclose(rebuilt, expected_rot, atol=1e-9)
 
     def test_unit_calculate_intersect_custom_vectors(self):

--- a/tests/test_compute/test_compute_spatial.py
+++ b/tests/test_compute/test_compute_spatial.py
@@ -78,6 +78,86 @@ class SpatialTestCase(unittest.TestCase):
                 allow_nans=False,
             )
 
+    def test_unit_frame_euler_invalid_sequence_raises(self):
+        ugps = np.array([1_000_000])
+        with self.assertRaises(ValueError):
+            spatial.frame_euler("A", "B", ugps, sequence=(1, 2))  # not three axes
+        with self.assertRaises(ValueError):
+            spatial.frame_euler("A", "B", ugps, sequence=(1, 4, 2))  # axis out of range
+        with self.assertRaises(ValueError):
+            spatial.frame_euler("A", "B", ugps, sequence=(1, 1, 2))  # adjacent repeat
+
+    def test_unit_frame_euler_degrees_and_columns(self):
+        # Angles are m2eul(pxform(...)) per sample; degrees converts from radians,
+        # columns/index follow the sequence order and ugps.
+        ugps = np.array([1_000_000, 2_000_000])
+        with (
+            patch.object(spatial.spicierpy.obj, "Frame"),
+            patch.object(spatial.spicetime, "adapt", return_value=np.array([10.0, 20.0])),
+            patch.object(spatial.spicierpy, "pxform", return_value=np.eye(3)),
+            patch.object(spatial.spicierpy, "m2eul", side_effect=[(0.0, np.pi / 2, np.pi), (np.pi, 0.0, np.pi / 4)]),
+        ):
+            df = spatial.frame_euler("INST_FRAME", "ITRF93", ugps)
+
+        assert list(df.columns) == ["euler1", "euler2", "euler3"]
+        assert df.index.name == "ugps"
+        npt.assert_allclose(df.iloc[0].values, [0.0, 90.0, 180.0])
+        npt.assert_allclose(df.iloc[1].values, [180.0, 0.0, 45.0])
+
+    def test_unit_frame_euler_radians_passthrough(self):
+        ugps = np.array([1_000_000])
+        with (
+            patch.object(spatial.spicierpy.obj, "Frame"),
+            patch.object(spatial.spicetime, "adapt", return_value=np.array([10.0])),
+            patch.object(spatial.spicierpy, "pxform", return_value=np.eye(3)),
+            patch.object(spatial.spicierpy, "m2eul", return_value=(0.1, 0.2, 0.3)),
+        ):
+            df = spatial.frame_euler("A", "B", ugps, degrees=False)
+        npt.assert_allclose(df.iloc[0].values, [0.1, 0.2, 0.3])
+
+    def test_unit_frame_euler_nan_fills_attitude_gap(self):
+        # A SPICE attitude gap NaN-fills under allow_nans, and raises without it.
+        ugps = np.array([1_000_000, 2_000_000])
+        gap = spicierpy.utils.exceptions.SpiceyError("SPICE(NOFRAMECONNECT)")
+        with (
+            patch.object(spatial.spicierpy.obj, "Frame"),
+            patch.object(spatial.spicetime, "adapt", return_value=np.array([10.0, 20.0])),
+            patch.object(spatial.spicierpy, "pxform", side_effect=gap),
+            patch.object(spatial.spicierpy, "m2eul"),
+        ):
+            df = spatial.frame_euler("A", "B", ugps, allow_nans=True)
+            assert df.shape == (2, 3)
+            assert np.isnan(df.values).all()
+
+            with self.assertRaises(spicierpy.utils.exceptions.SpiceyError):
+                spatial.frame_euler("A", "B", ugps, allow_nans=False)
+
+    @pytest.mark.extra
+    def test_frame_euler_matches_pointing_state(self):
+        # frame_euler is the standalone form of the Euler extraction inside
+        # instrument_pointing_state; over real kernels they must agree exactly.
+        ugps = spicetime.adapt(np.array(["2023-01-01", "2023-01-01T00:01"]), "iso")
+        with self.mkrn.load():
+            euler = spatial.frame_euler("CPRS_HYSICS_COORD", "ITRF93", ugps)
+            _, sc_data, _ = spatial.instrument_pointing_state(
+                ugps, "CPRS_HYSICS", pointing_frame="ITRF93", allow_nans=True
+            )
+        npt.assert_allclose(
+            euler[["euler1", "euler2", "euler3"]].values, sc_data[["ex", "ey", "ez"]].values, rtol=1e-9, atol=1e-9
+        )
+
+    @pytest.mark.extra
+    def test_frame_euler_reconstructs_rotation(self):
+        # Independent check: the returned angles rebuild the frame rotation via eul2m.
+        ugps = spicetime.adapt(np.array(["2023-01-01"]), "iso")
+        with self.mkrn.load():
+            euler = spatial.frame_euler("CPRS_HYSICS_COORD", "ITRF93", ugps, degrees=False)
+            et = spicetime.adapt(ugps, to="et")[0]
+            expected_rot = spicierpy.pxform("CPRS_HYSICS_COORD", "ITRF93", et)
+            e1, e2, e3 = euler.iloc[0].values
+            rebuilt = spicierpy.eul2m(e1, e2, e3, 1, 2, 3)
+        npt.assert_allclose(rebuilt, expected_rot, atol=1e-9)
+
     def test_unit_calculate_intersect_custom_vectors(self):
         """Test logic for handling custom pointing vectors (shapes broadcasting)."""
         mock_instrument = MagicMock(spec=spicierpy.obj.Body)


### PR DESCRIPTION
This pull request introduces a new utility function for computing Euler angles between reference frames over time, along with comprehensive unit tests to validate its behavior and integration. The main focus is on enabling flexible, robust extraction of frame-to-frame Euler angles using SPICE kernels, and ensuring correctness through both unit and integration-style tests.

### potential usage and downstream consumers
the consumers below are mostly future or illustrative, not yet wired:

1. In-repo (curryer spatial.py) — instrument_pointing_state already does this same math inline (m2eul(pxform(...), 1, 2, 3) → degrees). frame_euler is the standalone extraction of it. Folding the inline copy onto frame_euler is an optional later consolidation (rides the deferred spatial.py breakup) — not required for frame_euler to be complete.
2. Downstream (libera_rad) — the stage-by-stage motor Az/El loop on feature/geo-subsatellite-azel (geolocation.py:225–230) is the eventual rewire target. Caveat: that branch is an unmerged example, not production — it illustrates the manual pxform→m2eul pattern frame_euler will replace once curryer releases the primitive and libera_rad bumps the pin. LIBERA frames stay downstream; the conversion comes from curryer.
3. Future curryer field — gimbal Azimuth/Elevation (#64) — not yet implemented. It's in the convention-gated group, still pending the frame pair / Euler sequence and corrected-vs-raw decisions. When built, it will be a thin wrapper over frame_euler, and the libera_rad branch above is the candidate definition to reconcile against.

So this adds frame_euler as a ready building block now. Az/El (both the curryer field and the downstream rewire) is still to come — gated on conventions and on the downstream branches actually merging — so today's PR adds the reusable primitive ahead of those consumers, not the Az/El fields themselves.

**New Euler angle computation utility:**

* Added the `frame_euler` function to `curryer/compute/spatial.py`, which computes the Euler angles required to rotate one reference frame into another at specified times. This function is generic over frame pairs, supports custom axis sequences, handles both degrees and radians, and can optionally fill missing data with NaNs when SPICE coverage is incomplete.

**Comprehensive testing for new functionality:**

* Added a suite of unit tests in `tests/test_compute/test_compute_spatial.py` to verify:
  - Input validation for axis sequences (must be three axes, no repeats, valid range).
  - Correct output in both degrees and radians, with appropriate column names and index.
  - NaN-filling behavior for attitude gaps when `allow_nans=True`, and error propagation otherwise.
  - Consistency with the existing `instrument_pointing_state` function over real SPICE kernels.
  - Ability to reconstruct the original rotation matrix from the returned Euler angles, verifying mathematical correctness.
