### PR TITLE
support numpy 2 with spiceypy workaround

### DIFF
--- a/curryer/spicetime/convert.py
+++ b/curryer/spicetime/convert.py
@@ -38,6 +38,8 @@ import numpy as np
 from .. import spicierpy as sp
 from . import constants, leapsecond, native, utils
 
+_NUMPY_GE_2 = np.lib.NumpyVersion(np.__version__) >= "2.0.0"
+
 
 # TODO: Support format type of a SPICE clock obj (i.e., convert to/from sclk ticks).
 #   See methods `sce2c` and `sct2e`. Limited usage and requires kernels!
@@ -507,23 +509,18 @@ class SpiceTime(np.ndarray):
         # Set the `ttype`. Could be None if casting from a non-SpiceTime obj.
         self._ttype = getattr(obj, "ttype", None)
 
-    def __array_prepare__(self, out_arr, context=None):
-        """Numpy's way of supporting subclassing from ufuncs (e.g.,
-        `np.min(et_arr)`). Allows viewing (ONLY) the output data structure and
-        context (func & args) before the calculation.
-        """
-        # Prevent mixing with datetime64.
-        if out_arr.dtype.type == np.datetime64:
-            raise TypeError(
-                "Can not combine SpiceTime and numpy.datetime64 arrays. Datetime64 does not support leapseconds!"
-            )
-        return np.ndarray.__array_prepare__(self, out_arr, context)
-
-    def __array_wrap__(self, out_arr, context=None):
+    def __array_wrap__(self, out_arr, context=None, return_scalar=False):
         """Numpy's way of supporting subclassing from ufuncs (e.g.,
         `np.min(et_arr)`). Allows tweaking the output (`out_arr`), before final
         casting as `SpiceTime`.
         """
+        # Prevent mixing with datetime64. Numpy 2 removed `__array_prepare__`,
+        #   which used to raise this before the calculation, so it lives here.
+        if out_arr.dtype.type == np.datetime64:
+            raise TypeError(
+                "Can not combine SpiceTime and numpy.datetime64 arrays. Datetime64 does not support leapseconds!"
+            )
+
         # Cast timedelta output as the ttype's data type (e.g., int64 for ugps)
         #   but only if they use the same time units.
         if out_arr.dtype.type == np.timedelta64:
@@ -534,13 +531,21 @@ class SpiceTime(np.ndarray):
             search_units = re.search(r"\w+\[(\w{1,2})\]", out_arr.dtype.str)
             units = None if search_units is None else search_units.group(1)
 
-            if out_arr.ttype not in allowed_timedelta64_units.get(units, []):
+            # Numpy 2 passes the base-class array, so take the ttype from self.
+            ttype = getattr(out_arr, "ttype", None) or self.ttype
+            if ttype not in allowed_timedelta64_units.get(units, []):
                 raise TypeError(
                     f"Cannot combine ttype {self.ttype!r} with timedelta units {units!r} ({out_arr.dtype.str})"
                 )
-            out_arr = out_arr.astype(TTYPE_TO_DTYPE[out_arr.ttype])
+            out_arr = out_arr.astype(TTYPE_TO_DTYPE[ttype])
 
-        return np.ndarray.__array_wrap__(self, out_arr, context)
+        if _NUMPY_GE_2:
+            result = np.ndarray.__array_wrap__(self, out_arr, context, return_scalar)
+        else:
+            result = np.ndarray.__array_wrap__(self, out_arr, context)
+        if isinstance(result, SpiceTime) and result.ttype is None:
+            result._ttype = self.ttype
+        return result
 
     def __repr__(self):
         """String representation of the array with the time format `ttype`."""

--- a/curryer/spicetime/convert.py
+++ b/curryer/spicetime/convert.py
@@ -535,7 +535,7 @@ class SpiceTime(np.ndarray):
             ttype = getattr(out_arr, "ttype", None) or self.ttype
             if ttype not in allowed_timedelta64_units.get(units, []):
                 raise TypeError(
-                    f"Cannot combine ttype {self.ttype!r} with timedelta units {units!r} ({out_arr.dtype.str})"
+                    f"Cannot combine ttype {ttype!r} with timedelta units {units!r} ({out_arr.dtype.str})"
                 )
             out_arr = out_arr.astype(TTYPE_TO_DTYPE[ttype])
 

--- a/curryer/spicetime/convert.py
+++ b/curryer/spicetime/convert.py
@@ -534,9 +534,7 @@ class SpiceTime(np.ndarray):
             # Numpy 2 passes the base-class array, so take the ttype from self.
             ttype = getattr(out_arr, "ttype", None) or self.ttype
             if ttype not in allowed_timedelta64_units.get(units, []):
-                raise TypeError(
-                    f"Cannot combine ttype {ttype!r} with timedelta units {units!r} ({out_arr.dtype.str})"
-                )
+                raise TypeError(f"Cannot combine ttype {ttype!r} with timedelta units {units!r} ({out_arr.dtype.str})")
             out_arr = out_arr.astype(TTYPE_TO_DTYPE[ttype])
 
         if _NUMPY_GE_2:

--- a/curryer/spicierpy/__init__.py
+++ b/curryer/spicierpy/__init__.py
@@ -7,7 +7,16 @@
 #
 # Import everything from SpiceyPy. Required to "replace" issue methods.
 #
-from spiceypy import *
+try:
+    from spiceypy import *
+except AttributeError:
+    # SpiceyPy 8.1.0-8.1.2 have a broken `__all__` (a missing comma merges two
+    # entries into the bogus name "exceptionsstypes"), which kills wildcard
+    # imports. Fall back to copying the module's public namespace directly.
+    import spiceypy as _spiceypy
+
+    globals().update({_k: _v for _k, _v in vars(_spiceypy).items() if not _k.startswith("_")})
+    del _spiceypy
 
 #
 # Lastly load in the custom modules.

--- a/curryer/spicierpy/__init__.py
+++ b/curryer/spicierpy/__init__.py
@@ -9,7 +9,9 @@
 #
 try:
     from spiceypy import *
-except AttributeError:
+except AttributeError as e:
+    if "exceptionsstypes" not in str(e):
+        raise
     # SpiceyPy 8.1.0-8.1.2 have a broken `__all__` (a missing comma merges two
     # entries into the bogus name "exceptionsstypes"), which kills wildcard
     # imports. Fall back to copying the module's public namespace directly.

--- a/curryer/spicierpy/ext.py
+++ b/curryer/spicierpy/ext.py
@@ -456,7 +456,7 @@ def query_ephemeris(ugps_times, target, observer, ref_frame="J2000", correction=
     else:
         read_ephem = vectorized.spkezp
         default_columns = POSITION_COLUMNS
-    nan_output = np.array([np.NaN for _ in default_columns])
+    nan_output = np.array([np.nan for _ in default_columns])
 
     # Load SPICE mappings.
     target = Body(target)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,10 @@ dependencies = [
     "requests>=2.28",
     "jinja2>=3",
     # NOTE: SpiceyPy 8.1.0-8.1.2 ship a broken `__all__` that kills wildcard
-    # imports; curryer.spicierpy works around it (see issue #147).
-    "spiceypy>=6",
+    # imports; curryer.spicierpy works around it (see issue #147). SpiceyPy
+    # 8.1+ publishes no cp310 wheels, so cap it on 3.10 to avoid sdist builds.
+    "spiceypy>=6,<8.1; python_version < '3.11'",
+    "spiceypy>=6; python_version >= '3.11'",
     "openpyxl>=3",
     "numpy >=1.23,<3",
     "boto3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,11 @@ dependencies = [
     "pyproj>=3.6",
     "requests>=2.28",
     "jinja2>=3",
-    # NOTE: SpiceyPy 8.1+ breaks curryer compatibility. Keep this pin until
-    # that issue is resolved upstream/in curryer (CURRYER-148).
-    "spiceypy>=6,<8.1.0",
+    # NOTE: SpiceyPy 8.1.0-8.1.2 ship a broken `__all__` that kills wildcard
+    # imports; curryer.spicierpy works around it (see issue #147).
+    "spiceypy>=6",
     "openpyxl>=3",
-    "numpy >=1.23,<2.0",
+    "numpy >=1.23,<3",
     "boto3",
     "typing-extensions",
     "pydantic>=2.0",
@@ -110,6 +110,7 @@ select = [
     "S",  # flake8-bandit security
     "PT", # flake8-pytest-style
     "UP", # pyupgrade syntax upgrader
+    "NPY201", # numpy 2 migration: flag APIs removed in numpy 2
 ]
 per-file-ignores = { "tests/*" = [
     "S",

--- a/tests/test_compute/test_compute_elevation.py
+++ b/tests/test_compute/test_compute_elevation.py
@@ -419,11 +419,11 @@ class ElevationTestCase(unittest.TestCase):
         yy = np.tile(y, (x.size, 1)).T
 
         _, _, wgs84_z = transformer.transform(xx[idx], yy[idx], usgs_hts[idx])
-        wgs84_hts = np.full(usgs_hts.shape, np.NaN, dtype=np.float64)  # Source is int16!!!
+        wgs84_hts = np.full(usgs_hts.shape, np.nan, dtype=np.float64)  # Source is int16!!!
         wgs84_hts[idx] = wgs84_z
 
         _, _, geoid_z = transformer.transform(xx[idx], yy[idx], np.zeros(xx[idx].size))
-        geoid_hts = np.full(usgs_hts.shape, np.NaN, dtype=np.float64)  # Source is int16!!!
+        geoid_hts = np.full(usgs_hts.shape, np.nan, dtype=np.float64)  # Source is int16!!!
         geoid_hts[idx] = geoid_z
 
         # Geoid has some differences (more tolerant due to potential format conversion).

--- a/tests/test_spicierpy/test_spicierpy_vectorized.py
+++ b/tests/test_spicierpy/test_spicierpy_vectorized.py
@@ -145,7 +145,9 @@ class VectorizedTestCase(unittest.TestCase):
                     abcorr=self.correction,
                     ref=self.reference_frame,
                 )
-            self.assertIn("only length-1 arrays can be converted", raised.exception.args[0])
+            # Numpy 2 reworded the error from "only length-1 arrays can be
+            #   converted" to "only 0-dimensional arrays can be converted".
+            self.assertRegex(raised.exception.args[0], "only (length-1|0-dimensional) arrays can be converted")
 
             # Doesn't support target name (string).
             with self.assertRaises(TypeError) as raised:
@@ -307,7 +309,7 @@ class VectorizedTestCase(unittest.TestCase):
         self.assertListEqual(["2000-01-01T12:00:01", "2000-01-01T12:00:01", "2000-01-01T12:00:01"], list(utc[:, 1]))
 
         # # Proof that the original library does not support them.
-        with self.assertRaisesRegex(TypeError, "only length-1 arrays"):
+        with self.assertRaisesRegex(TypeError, "only (length-1|0-dimensional) arrays"):
             spiceypy.timout(np.stack([test_et_values, test_et_values]), fmt, n_char)
 
     def test_unitim_vectorized(self):


### PR DESCRIPTION
This pull request updates the codebase to support both NumPy 1.x and 2.x, removes a restrictive pin on the `spiceypy` version, and improves compatibility and error handling for recent upstream changes. It also updates tests and code to use consistent `np.nan` usage and adapts to error message changes in NumPy 2.

**NumPy 2 compatibility:**
- Updated `curryer/spicetime/convert.py` to handle API changes in NumPy 2, including replacing the removed `__array_prepare__` with enhanced logic in `__array_wrap__`, and adding version checks to ensure correct behavior across NumPy versions. [[1]](diffhunk://#diff-71c186efbbfd9559f1bd4d12f5baef73aa92c453f95c15cbbc760c81d1acc31fR41-R42) [[2]](diffhunk://#diff-71c186efbbfd9559f1bd4d12f5baef73aa92c453f95c15cbbc760c81d1acc31fL510-L526) [[3]](diffhunk://#diff-71c186efbbfd9559f1bd4d12f5baef73aa92c453f95c15cbbc760c81d1acc31fL537-R548)
- Relaxed the `numpy` dependency version pin in `pyproject.toml` to allow NumPy 2.x, and added a flake8 rule for NumPy 2 migration warnings. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L56-R60) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R113)
- Updated tests to match new NumPy 2 error messages, using regex to allow for both old and new wording. [[1]](diffhunk://#diff-d9b2c5e6fa28d11aae38e26064999f0efa4493f20881a4e9965f1eb01ad5b434L148-R150) [[2]](diffhunk://#diff-d9b2c5e6fa28d11aae38e26064999f0efa4493f20881a4e9965f1eb01ad5b434L310-R312)

**SpiceyPy compatibility:**
- Removed the upper version pin on `spiceypy` and implemented a fallback import mechanism in `curryer/spicierpy/__init__.py` to work around a broken `__all__` in SpiceyPy 8.1.0–8.1.2. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L56-R60) [[2]](diffhunk://#diff-5969511830bf25fefcde9e098a56560b0f2937296134d03a5571cb4f2d3202ddR10-R19)

**Code and test cleanup:**
- Replaced all uses of `np.NaN` with the canonical `np.nan` for consistency and to avoid deprecation warnings. [[1]](diffhunk://#diff-2dc9844d34ae893d0e0b16dcaee7dbb8c0aa014106ae52bb78a5f6d0a6a5519cL459-R459) [[2]](diffhunk://#diff-be539da8ff8b51b50a304be0f9e124ff43c7c7382f64cfcdffc4251163aaa0faL422-R426)

These changes ensure that the codebase remains compatible with the latest upstream dependencies and continues to function correctly with both older and newer versions of NumPy and SpiceyPy.