### PR TITLE
KM: PR 1 Kernel loading

### DIFF
--- a/curryer/spicierpy/ext.py
+++ b/curryer/spicierpy/ext.py
@@ -100,6 +100,56 @@ class load_kernel:
             raise ValueError("Must specify `kernel` (str) or `all`=True.")
 
 
+class LoadedKernel(typing.NamedTuple):
+    """A kernel currently furnished in the SPICE kernel pool.
+
+    Attributes
+    ----------
+    file : str
+        Kernel file path, as it was furnished.
+    ktype : str
+        SPICE kernel type (e.g. ``"SPK"``, ``"CK"``, ``"PCK"``, ``"TEXT"``, ``"META"``).
+    source : str
+        Name of the source file that furnished this kernel (e.g. a meta-kernel),
+        or an empty string if it was furnished directly.
+    handle : int
+        SPICE integer handle for binary kernels; 0 for text kernels.
+    """
+
+    file: str
+    ktype: str
+    source: str
+    handle: int
+
+
+def loaded_kernels(kind="ALL"):
+    """List the kernels currently furnished in the SPICE kernel pool.
+
+    Queries the kernel pool itself (``ktotal`` / ``kdata``), so the result reflects
+    every furnished kernel regardless of which component loaded it — unlike
+    :attr:`load_kernel.loaded`, which tracks only the kernels loaded through that
+    handle. Useful for verifying furnish state and for pool-wide diagnostics.
+
+    Parameters
+    ----------
+    kind : str, optional
+        SPICE kernel kind filter: one of ``"SPK"``, ``"CK"``, ``"PCK"``, ``"DSK"``,
+        ``"EK"``, ``"TEXT"``, ``"META"``, a space-delimited combination, or ``"ALL"``.
+        Default="ALL".
+
+    Returns
+    -------
+    list of LoadedKernel
+        One record per furnished kernel, in load order.
+
+    """
+    records = []
+    for which in range(spiceypy.ktotal(kind)):
+        file, ktype, source, handle = spiceypy.kdata(which, kind)
+        records.append(LoadedKernel(file=file, ktype=ktype, source=source, handle=handle))
+    return records
+
+
 def object_frame(obj_name, as_id=False):
     """Retrieve frame name/id associated with an object name or id.
 

--- a/curryer/spicierpy/ext.py
+++ b/curryer/spicierpy/ext.py
@@ -3,6 +3,7 @@
 @author: Brandon Stone
 """
 
+import enum
 import logging
 import os
 import shutil
@@ -100,6 +101,28 @@ class load_kernel:
             raise ValueError("Must specify `kernel` (str) or `all`=True.")
 
 
+class KernelType(str, enum.Enum):
+    """SPICE kernel-pool type categories, as used by ``ktotal`` / ``kdata``.
+
+    These are the pool's load-time categories, not file formats: SPICE
+    collapses every text kernel (LSK, FK, IK, SCLK, text PCK, meta-kernel
+    contents, ...) into ``TEXT``, so a text PCK is reported as ``TEXT``,
+    never ``PCK``. ``PCK`` matches only binary PCKs.
+
+    Members are plain strings (``KernelType.SPK == "SPK"``) and may be passed
+    anywhere SPICE expects a kind string.
+    """
+
+    SPK = "SPK"
+    CK = "CK"
+    PCK = "PCK"
+    DSK = "DSK"
+    EK = "EK"
+    TEXT = "TEXT"
+    META = "META"
+    ALL = "ALL"
+
+
 class LoadedKernel(typing.NamedTuple):
     """A kernel currently furnished in the SPICE kernel pool.
 
@@ -122,7 +145,9 @@ class LoadedKernel(typing.NamedTuple):
     handle: int
 
 
-def loaded_kernels(kind="ALL"):
+def loaded_kernels(
+    kind: str | KernelType | typing.Iterable[str | KernelType] = KernelType.ALL,
+) -> list[LoadedKernel]:
     """List the kernels currently furnished in the SPICE kernel pool.
 
     Queries the kernel pool itself (``ktotal`` / ``kdata``), so the result reflects
@@ -132,10 +157,11 @@ def loaded_kernels(kind="ALL"):
 
     Parameters
     ----------
-    kind : str, optional
-        SPICE kernel kind filter: one of ``"SPK"``, ``"CK"``, ``"PCK"``, ``"DSK"``,
-        ``"EK"``, ``"TEXT"``, ``"META"``, a space-delimited combination, or ``"ALL"``.
-        Default="ALL".
+    kind : str or KernelType or iterable of them, optional
+        Kernel kind filter: one or more :class:`KernelType` values (or their
+        string equivalents), or a space-delimited combination string. Note
+        that all text kernels report as ``TEXT`` (see :class:`KernelType`).
+        Default=``KernelType.ALL``.
 
     Returns
     -------
@@ -143,9 +169,13 @@ def loaded_kernels(kind="ALL"):
         One record per furnished kernel, in load order.
 
     """
+    if not isinstance(kind, str):
+        kind = " ".join(kind)
     records = []
     for which in range(spiceypy.ktotal(kind)):
-        file, ktype, source, handle = spiceypy.kdata(which, kind)
+        # Slice guards against the 5-tuple (extra `found` flag) that kdata
+        # returns when spiceypy's `catch_false_founds` config is disabled.
+        file, ktype, source, handle = spiceypy.kdata(which, kind)[:4]
         records.append(LoadedKernel(file=file, ktype=ktype, source=source, handle=handle))
     return records
 

--- a/tests/test_spicierpy/test_spicierpy_ext.py
+++ b/tests/test_spicierpy/test_spicierpy_ext.py
@@ -123,21 +123,23 @@ class ExtTestCase(unittest.TestCase):
         self.assertIn("Must specify `kernel` (str) or `all`=True.", raised.exception.args[0])
 
     def test_loaded_kernels_lists_pool(self):
-        # Robust to kernels other tests may have left furnished: assert on the delta.
-        baseline = len(ext.loaded_kernels())
+        # Robust to kernels other tests may have left furnished (or SPICE
+        # de-duplicating a re-furnish): assert on membership and on the pool's
+        # file set returning to the baseline, not on counts.
+        baseline_files = {rec.file for rec in ext.loaded_kernels()}
         with ext.load_kernel(self.kernels_all):
             records = ext.loaded_kernels()
-            self.assertEqual(baseline + len(self.kernels_all), len(records))
             listed_files = {rec.file for rec in records}
             for kernel_file in self.kernels_all:
                 self.assertIn(str(kernel_file), listed_files)
+            self.assertTrue(baseline_files.issubset(listed_files))
             for rec in records:
                 self.assertIsInstance(rec, ext.LoadedKernel)
                 self.assertIsInstance(rec.file, str)
                 self.assertIsInstance(rec.ktype, str)
                 self.assertIsInstance(rec.source, str)
                 self.assertIsInstance(rec.handle, int)
-        self.assertEqual(baseline, len(ext.loaded_kernels()))
+        self.assertEqual(baseline_files, {rec.file for rec in ext.loaded_kernels()})
 
     def test_loaded_kernels_kind_filter(self):
         with ext.load_kernel(self.kernels_all):
@@ -147,6 +149,7 @@ class ExtTestCase(unittest.TestCase):
             expected_spks = {str(fn) for fn in self.kernels["ephemeris"]}
             self.assertTrue(expected_spks.issubset({rec.file for rec in spk_records}))
             text_records = ext.loaded_kernels(kind="TEXT")
+            self.assertTrue(text_records)
             self.assertTrue(all(rec.ktype == "TEXT" for rec in text_records))
             self.assertTrue(all(rec.handle == 0 for rec in text_records))
 

--- a/tests/test_spicierpy/test_spicierpy_ext.py
+++ b/tests/test_spicierpy/test_spicierpy_ext.py
@@ -122,6 +122,34 @@ class ExtTestCase(unittest.TestCase):
                 kern.unload(kernel=123)
         self.assertIn("Must specify `kernel` (str) or `all`=True.", raised.exception.args[0])
 
+    def test_loaded_kernels_lists_pool(self):
+        # Robust to kernels other tests may have left furnished: assert on the delta.
+        baseline = len(ext.loaded_kernels())
+        with ext.load_kernel(self.kernels_all):
+            records = ext.loaded_kernels()
+            self.assertEqual(baseline + len(self.kernels_all), len(records))
+            listed_files = {rec.file for rec in records}
+            for kernel_file in self.kernels_all:
+                self.assertIn(str(kernel_file), listed_files)
+            for rec in records:
+                self.assertIsInstance(rec, ext.LoadedKernel)
+                self.assertIsInstance(rec.file, str)
+                self.assertIsInstance(rec.ktype, str)
+                self.assertIsInstance(rec.source, str)
+                self.assertIsInstance(rec.handle, int)
+        self.assertEqual(baseline, len(ext.loaded_kernels()))
+
+    def test_loaded_kernels_kind_filter(self):
+        with ext.load_kernel(self.kernels_all):
+            spk_records = ext.loaded_kernels(kind="SPK")
+            self.assertTrue(spk_records)
+            self.assertTrue(all(rec.ktype == "SPK" for rec in spk_records))
+            expected_spks = {str(fn) for fn in self.kernels["ephemeris"]}
+            self.assertTrue(expected_spks.issubset({rec.file for rec in spk_records}))
+            text_records = ext.loaded_kernels(kind="TEXT")
+            self.assertTrue(all(rec.ktype == "TEXT" for rec in text_records))
+            self.assertTrue(all(rec.handle == 0 for rec in text_records))
+
     def test_object_frame(self):
         # Load the kernels to activate name <--> code.
         #   Load frame kernel for name <--> code.

--- a/tests/test_spicierpy/test_spicierpy_ext.py
+++ b/tests/test_spicierpy/test_spicierpy_ext.py
@@ -153,6 +153,24 @@ class ExtTestCase(unittest.TestCase):
             self.assertTrue(all(rec.ktype == "TEXT" for rec in text_records))
             self.assertTrue(all(rec.handle == 0 for rec in text_records))
 
+    def test_loaded_kernels_kind_enum_and_list(self):
+        with ext.load_kernel(self.kernels_all):
+            spk_records = ext.loaded_kernels(kind="SPK")
+            self.assertEqual(spk_records, ext.loaded_kernels(kind=ext.KernelType.SPK))
+
+            # A list of kinds matches the union of the individual filters.
+            combined = ext.loaded_kernels(kind=[ext.KernelType.SPK, "TEXT"])
+            expected = {rec.file for rec in spk_records} | {rec.file for rec in ext.loaded_kernels(kind="TEXT")}
+            self.assertEqual(expected, {rec.file for rec in combined})
+            self.assertTrue(combined)
+
+            # Text PCKs report as TEXT, never PCK (see KernelType docstring):
+            # the PCK (binary-only) filter must not include the .tpc kernels.
+            text_pcks = {str(fn) for fn in self.kernels_all if fn.suffix == ".tpc"}
+            self.assertTrue(text_pcks)
+            pck_files = {rec.file for rec in ext.loaded_kernels(kind=ext.KernelType.PCK)}
+            self.assertFalse(text_pcks & pck_files)
+
     def test_object_frame(self):
         # Load the kernels to activate name <--> code.
         #   Load frame kernel for name <--> code.


### PR DESCRIPTION
This pull request introduces a new utility for inspecting the currently loaded SPICE kernels and adds comprehensive tests to ensure its correctness and flexibility.

**New kernel pool inspection utility:**

* Added a `LoadedKernel` named tuple to `ext.py` to represent metadata about each furnished kernel, including its file path, type, source, and handle.
* Introduced the `loaded_kernels` function in `ext.py`, which queries the SPICE kernel pool directly and returns a list of `LoadedKernel` records, supporting filtering by kernel type.

**Testing and validation:**

* Added `test_loaded_kernels_lists_pool` to verify that `loaded_kernels` accurately reflects the pool state, including correct file listing and type checking.
* Added `test_loaded_kernels_kind_filter` to ensure the `kind` filter works as expected for different kernel types, including type and handle validation.