### PR TITLE
BUGFIX: Fix spicierpy.utils export for SpiceyPy 8.2 and drop the version cap

### DIFF
--- a/curryer/spicierpy/__init__.py
+++ b/curryer/spicierpy/__init__.py
@@ -20,6 +20,11 @@ except AttributeError as e:
     globals().update({_k: _v for _k, _v in vars(_spiceypy).items() if not _k.startswith("_")})
     del _spiceypy
 
+# SpiceyPy 8.1+ defines `__all__`, which omits the `utils` submodule from the
+# wildcard import (earlier versions had no `__all__`, so `utils` came along
+# implicitly). Import it explicitly to keep `spicierpy.utils` available.
+from spiceypy import utils
+
 #
 # Lastly load in the custom modules.
 #
@@ -40,4 +45,4 @@ from .vectorized import (  # Time-related  # Ephemeris
     unitim,
 )
 
-__all__ = ["ext", "obj", "ckgp", "recgeo", "sce2c", "sct2e", "spkezp", "spkezr", "str2et", "timout", "unitim"]
+__all__ = ["ext", "obj", "utils", "ckgp", "recgeo", "sce2c", "sct2e", "spkezp", "spkezr", "str2et", "timout", "unitim"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,10 @@ dependencies = [
     "pyproj>=3.6",
     "requests>=2.28",
     "jinja2>=3",
-    # NOTE: SpiceyPy 8.1.0-8.1.2 ship a broken `__all__` that kills wildcard
-    # imports; curryer.spicierpy works around it (see issue #147). SpiceyPy
-    # 8.1+ publishes no cp310 wheels, so cap it on 3.10 to avoid sdist builds.
-    "spiceypy>=6,<8.1; python_version < '3.11'",
-    "spiceypy>=6; python_version >= '3.11'",
+    # NOTE: SpiceyPy 8.2.0 fixed the broken `__all__` shipped in 8.1.0-8.1.2
+    # (curryer.spicierpy works around it, see issue #147) and restored cp310
+    # wheels, so no version cap is needed.
+    "spiceypy>=6",
     "openpyxl>=3",
     "numpy >=1.23,<3",
     "boto3",


### PR DESCRIPTION
SpiceyPy 8.1+ defines __all__, which omits the utils submodule from the wildcard import that earlier versions swept in implicitly, breaking spicierpy.utils on 8.2.0. Re-export it explicitly. SpiceyPy 8.2.0 also restored cp310 wheels, so the Python 3.10 version cap is no longer needed.


This pull request updates the handling of the `spiceypy` dependency and improves the import behavior for the `spicierpy` package. The main focus is on ensuring compatibility with recent `spiceypy` versions and making the `utils` submodule consistently available.

Dependency updates:

* Updated the `spiceypy` dependency in `pyproject.toml` to require version 6 or higher without any upper version cap, since version 8.2.0 fixed previous issues with the `__all__` attribute and restored Python 3.10 wheels.

Import and module availability improvements:

* Explicitly imported the `utils` submodule from `spiceypy` in `curryer/spicierpy/__init__.py` to ensure it is available, regardless of the `spiceypy` version, maintaining backward compatibility.
* Added `utils` to the `__all__` list in `curryer/spicierpy/__init__.py` so it is included in wildcard imports, making its availability explicit and consistent.