### PR TITLE
Set attainable project and tests coverage floors in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,27 +1,32 @@
-# Codecov configuration for space_packet_parser
+# Codecov configuration for curryer
 # https://docs.codecov.com/docs/codecovyml-reference
+#
+# CI measures the fast test suite only: @pytest.mark.extra tests and integration
+# tests that depend on data files not committed to the repo are skipped, so
+# measured coverage sits well below what the full suite exercises. The project
+# and tests targets are therefore floors set just under the measured levels on
+# main (project 78.8%, tests 87.7% as of 2026-08): they fail only on a genuine
+# regression, not on every PR. Ratchet them up as measured coverage rises.
+# Patch coverage is the high bar that applies to new and changed code.
 
 coverage:
   status:
     project:
       default:
-        target: 85% # Target coverage percentage
-        threshold: 5% # Allow 5% drop without failing
+        target: 75% # Floor under measured project coverage
         if_no_uploads: error # Fail if no coverage data
         only_pulls: false # Check coverage on all commits
 
-      # Custom group for tests module with higher threshold
       tests:
-        target: 95% # Very high threshold for test files
-        threshold: 1% # Allow only 1% drop
+        target: 85% # Floor under measured tests/** coverage; skipped tests count as uncovered
         paths:
-          - "tests/**" # Adjust this path to match your test directory
+          - "tests/**"
         if_no_uploads: error
         only_pulls: false
 
     patch:
       default:
-        target: 85% # Lower threshold for new code
+        target: 85% # High bar for new and changed code
         threshold: 5%
         only_pulls: true # Only check patch coverage on PRs
 


### PR DESCRIPTION
## Summary

The Codecov `project` and `project/tests` statuses fail on every PR because their targets
(85% / 95%) are structurally unreachable: CI measures the fast test suite only —
`@pytest.mark.extra` tests are deselected and integration tests that depend on data files
not committed to the repo skip themselves — capping measured coverage on `main` at
**78.8% project / 87.7% tests/**. This PR replaces those targets with floors just under
the measured levels: **project 75%, tests 85%**. Patch coverage stays at **85%** and
remains the quality gate for new and changed code.

## Why these numbers are reasonable

- **They pass today and fail only on genuine regressions.** Dropping project coverage
  from 78.8% below 75% means on the order of 550+ lines going uncovered — a real event
  worth blocking, not line-count noise.
- **The ~3-point headroom is deliberate.** A PR that adds a data-dependent or
  `extra`-marked test module lowers *measured* coverage through no fault of the code;
  the headroom absorbs that. This is also why `target: auto` (compare-to-base) was
  rejected — it would fail spuriously on exactly those PRs, recreating the always-fails
  problem.
- **Patch >= 85% does the real work.** New code must be well covered, which ratchets
  project coverage upward over time; the floors are documented in the file as values to
  raise as measured coverage rises.
- **`threshold` removed from the two project statuses.** Codecov's docs are ambiguous
  about whether threshold buffers a fixed (non-`auto`) target, so the floors are set to
  pass without depending on it.